### PR TITLE
Add language view support for c#

### DIFF
--- a/app/components/preview/Preview.tsx
+++ b/app/components/preview/Preview.tsx
@@ -36,9 +36,7 @@ export function Preview() {
               : undefined,
           backdropFilter: theme?.style['background.appearance'] === 'blurred' ? 'blur(20px)' : 'none',
           minWidth: 800,
-          maxWidth: 1000,
           minHeight: 600,
-          maxHeight: 800,
           ...cssStyleVars,
         }}
       >

--- a/app/components/preview/components/Breadcrumbs.tsx
+++ b/app/components/preview/components/Breadcrumbs.tsx
@@ -7,10 +7,15 @@ import MagnifyingGlassIcon from '~/assets/icons/magnifying_glass.svg?react';
 import ReplaceIcon from '~/assets/icons/replace.svg?react';
 import SelectAllIcon from '~/assets/icons/select_all.svg?react';
 import WordSearchIcon from '~/assets/icons/word_search.svg?react';
-import { cssVarStyleToken, cssVarSyntaxColorToken } from '~/utils/cssVarTokens';
+import { languagePacks, useLanguage } from '~/providers/language';
+import { cssVarStyleToken } from '~/utils/cssVarTokens';
 import { GhostButton } from './GhostButton';
 
 export function Breadcrumbs() {
+  const { language } = useLanguage();
+
+  const Breadcrumbs = languagePacks[language].breadcrumbs;
+
   return (
     <div
       className="flex flex-col border-b"
@@ -22,30 +27,7 @@ export function Breadcrumbs() {
       <div id="editor-breadcrums" className="flex px-2 py-1">
         <div className="ml-1 flex flex-1 items-center">
           <GhostButton style={{ paddingInline: '4px' }}>
-            <div className="flex items-center gap-2">
-              <div className="text-md" style={{ color: cssVarStyleToken('text.muted') }}>
-                src/pages/Home.tsx
-              </div>
-              <span className="text-xs" style={{ color: cssVarStyleToken('text.muted') }}>
-                &gt;
-              </span>
-              <span className="text-md pr-1" style={{ color: cssVarSyntaxColorToken('keyword') }}>
-                function
-              </span>
-              <span>
-                <span className="text-md" style={{ color: cssVarSyntaxColorToken('type') }}>
-                  App
-                </span>
-                <span
-                  className="text-md"
-                  style={{
-                    color: cssVarSyntaxColorToken('punctuation.bracket'),
-                  }}
-                >
-                  ()
-                </span>
-              </span>
-            </div>
+            <div className="flex items-center gap-2">{Breadcrumbs}</div>
           </GhostButton>
         </div>
         <div className="flex items-center gap-2">

--- a/app/components/preview/components/Code.tsx
+++ b/app/components/preview/components/Code.tsx
@@ -1,4 +1,5 @@
 import { type CSSProperties, type PropsWithChildren, type ReactNode, type UIEvent, useState } from 'react';
+import { languagePacks, useLanguage } from '~/providers/language';
 import {
   cssVarStyleToken,
   cssVarSyntaxColorToken,
@@ -13,7 +14,7 @@ const EXTRA_LINES = 10;
 
 type SNProps = PropsWithChildren<{ s: SyntaxTokens }>;
 
-const SN = (props: SNProps) => {
+export const SN = (props: SNProps) => {
   return (
     <span
       data-attribute={`syntax.${props.s}`}
@@ -28,7 +29,7 @@ const SN = (props: SNProps) => {
   );
 };
 
-const Popup = (props: PropsWithChildren<{ style: CSSProperties; content: ReactNode }>) => {
+export const Popup = (props: PropsWithChildren<{ style: CSSProperties; content: ReactNode }>) => {
   const [show, setShow] = useState(false);
   return (
     <span className="relative">
@@ -44,435 +45,38 @@ const Popup = (props: PropsWithChildren<{ style: CSSProperties; content: ReactNo
   );
 };
 
-const SP = () => <span>&nbsp;</span>;
-const Indent = () => (
-  <>
-    <SP />
-    <SP />
-  </>
-);
-const LA = () => <SN s="keyword">&#60;</SN>;
-const LAF = () => <SN s="keyword">&#60;&#47;</SN>;
-const RA = () => <SN s="keyword">&#62;</SN>;
-const LB = () => <SN s="punctuation.bracket">&#123;</SN>;
-const RB = () => <SN s="punctuation.bracket">&#125;</SN>;
-const LP = () => <SN s="punctuation.bracket">&#40;</SN>;
-const RP = () => <SN s="punctuation.bracket">&#41;</SN>;
-
-const ACTIVE_ROW = 10;
-
-const lines = [
-  <div key="line1">
-    <span
-      style={{
-        textDecorationLine: 'underline',
-        textDecorationStyle: 'wavy',
-        textDecorationColor: cssVarStyleToken('error'),
-      }}
-    >
-      <SN s="keyword">import</SN>
-      <SP />
-      <SN s="variable">fs</SN>
-      <SP />
-      <SN s="keyword">from</SN>
-      <SP />
-      <SN s="string">&#34;fs&#34;</SN>
-      <SN s="punctuation.delimiter">;</SN>
-    </span>
-    <br />
-    <span
-      style={{
-        color: cssVarStyleToken('error'),
-      }}
-    >
-      &#39;fs&#39; is declared but its value is never read.
-    </span>
-  </div>,
-  <SN key="line2" s="comment">
-    &#47;&#47; simple comment
-  </SN>,
-  <SN key="line3" s="comment.doc">
-    &#47;** @param &#123;string&#125; a block comment **&#47;
-  </SN>,
-  <span key="line4">
-    <SN s="keyword">type</SN>
-    <SP />
-    <SN s="type">Prop</SN>
-    <SP />
-    <SN s="operator">=</SN>
-    <SP />
-    <LB />
-    <SP />
-    <SN s="property">a</SN>
-    <SN s="punctuation.delimiter">;</SN>
-    <SP />
-    <SN s="type">boolean</SN>
-    <SN s="punctuation.delimiter">;</SN>
-    <SP />
-    <SN s="property">b</SN>
-    <SN s="punctuation.delimiter">:</SN>
-    <SP />
-    <SN s="constant">null</SN>
-    <SN s="punctuation.delimiter">;</SN>
-    <SP />
-    <SN s="property">c</SN>
-    <SN s="punctuation.delimiter">:</SN>
-    <SP />
-    <SN s="type">string</SN>
-    <SP />
-    <RB />
-    <SN s="punctuation.delimiter">;</SN>
-  </span>,
-  <span key="line5">
-    <SN s="keyword">enum</SN>
-    <SP />
-    <SN s="type">
-      <Popup
-        style={{
-          color: cssVarStyleToken('error'),
-          backgroundColor: cssVarStyleToken('error.background'),
-          borderColor: cssVarStyleToken('error.border'),
-        }}
-        content="'Enum' is declared but never used."
-      >
-        <span
-          style={{
-            textDecorationLine: 'underline',
-            textDecorationStyle: 'wavy',
-            textDecorationColor: cssVarStyleToken('error'),
-          }}
-        >
-          Enum
-        </span>
-      </Popup>
-    </SN>
-    <SP />
-    <LB />
-    <SP />
-    <SN s="property">zed</SN>
-    <SP />
-    <SN s="operator">=</SN>
-    <SP />
-    <SN s="string">&#39;zed&#39;</SN>
-    <SP />
-    <RB />
-  </span>,
-  <span key="line6">
-    <SN s="keyword">const</SN>
-    <SP />
-    <SN s="variable">number</SN>
-    <SP />
-    <SN s="operator">=</SN>
-    <SP />
-    <SN s="number">1</SN>
-    <SN s="punctuation.delimiter">;</SN>
-  </span>,
-  <span key="line7">
-    <SN s="keyword">const</SN>
-    <SP />
-    <SN s="variable">string</SN>
-    <SP />
-    <SN s="operator">=</SN>
-    <SP />
-    <Popup
-      style={{
-        color: cssVarStyleToken('warning'),
-        backgroundColor: cssVarStyleToken('warning.background'),
-        borderColor: cssVarStyleToken('warning.border'),
-      }}
-      content={'Typo in the word "strig"'}
-    >
-      <span
-        style={{
-          textDecorationLine: 'underline',
-          textDecorationStyle: 'wavy',
-          textDecorationColor: cssVarStyleToken('warning'),
-        }}
-      >
-        <SN s="string">&#34;strig&#34;</SN>
-      </span>
-    </Popup>
-
-    <SN s="punctuation.delimiter">;</SN>
-  </span>,
-  <span key="line8">
-    <SN s="keyword">const</SN>
-    <SP />
-    <SN s="variable">boolean</SN>
-    <SP />
-    <SN s="operator">=</SN>
-    <SP />
-    <SN s="boolean">true</SN>
-    <SN s="punctuation.delimiter">;</SN>
-  </span>,
-  <span key="line9">
-    <SN s="keyword">const</SN>
-    <SP />
-    <SN s="variable">object</SN>
-    <SP />
-    <SN s="operator">=</SN>
-    <SP />
-    <LB />
-    <SP />
-    <SN s="property">id</SN>
-    <SN s="punctuation.delimiter">:</SN>
-    <SP />
-    <SN s="string">`</SN>
-    <SN s="punctuation.special">$&#123;</SN>
-    <SN s="variable">string</SN>
-    <SN s="punctuation.special">&#125;</SN>
-    <SN s="string">_id1`</SN>
-    <SP />
-    <RB />
-    <SP />
-    <SN s="punctuation.delimiter">;</SN>
-  </span>,
-  <span key="line10">
-    <SN s="keyword">const</SN>
-    <SP />
-    <SN s="variable">regex</SN>
-    <SP />
-    <SN s="operator">=</SN>
-    <SP />
-    <SN s="operator">/</SN>
-    <SN s="string.regex">(L^\d]string).*</SN>
-    <SN s="operator">/</SN>
-    <SN s="string.regex">i</SN>
-    <SN s="punctuation.delimiter">;</SN>
-  </span>,
-  <span key="line11" className="flex">
-    <SN s="keyword">export</SN>
-    <SP />
-    <SN s="keyword">default</SN>
-    <SP />
-    <SN s="keyword">function</SN>
-    <SP />
-    <SN s="type">App</SN>
-    <SN s="keyword">
-      <LA />
-    </SN>
-    <SN s="type">T</SN>
-    <SP />
-    <SN s="keyword">extends</SN>
-    <SP />
-    <SN s="type">Prop</SN>
-    <SP />
-    <SN s="operator">=</SN>
-    <SP />
-    <SN s="type">object</SN>
-    <SN s="keyword">
-      <RA />
-    </SN>
-    <LP />
-    <SN s="variable">p</SN>
-    <SN s="punctuation.delimiter">:</SN>
-    <SP />
-    <SN s="type">T</SN>
-    <RP />
-    <SN s="punctuation.delimiter">:</SN>
-    <SP />
-    <SN s="type">any</SN>
-    <SP />
-    <LB />
-    <SP />
-    <span
-      className="blink h-full"
-      style={{
-        backgroundColor: cssVarStyleToken('text.accent'),
-        width: '2px',
-      }}
-    />
-  </span>,
-  <span key="line12">
-    <Indent />
-    <SN s="keyword">if</SN>
-    <SP />
-    <LP />
-    <SN s="variable">p</SN>
-    <SP />
-    <SN s="operator">==</SN>
-    <SP />
-    <SN s="boolean">true</SN>
-    <RP />
-    <SP />
-    <SN s="keyword">return</SN>
-    <SP />
-    <SN s="constant">null</SN>
-    <SN s="punctuation.delimiter">;</SN>
-  </span>,
-  <span key="line13">
-    <Indent />
-    <SN s="keyword">return</SN>
-    <SP />
-    <LP />
-  </span>,
-  <span key="line14">
-    <Indent />
-    <Indent />
-    <LA />
-    <SN s="tag">div</SN>
-    <SP />
-    <SN s="attribute">className</SN>
-    <SN s="keyword">=</SN>
-    <SN s="string">&#34;class1&#34;</SN>
-    <SP />
-    <SN s="attribute">style</SN>
-    <SN s="keyword">=</SN>
-    <LB />
-    <LB />
-    <SP />
-    <SN s="property">test</SN>
-    <SN s="punctuation.delimiter">:</SN>
-    <SP />
-    <SN s="number">1</SN>
-    <SP />
-    <RB />
-    <RB />
-    <RA />
-  </span>,
-  <span key="line15">
-    <Indent />
-    <Indent />
-    <Indent />
-    hello world
-    <SP />
-    <LB />
-    <SN s="variable">p</SN>
-    <SN s="punctuation.delimiter">.</SN>
-    <SN s="property">name</SN>
-    <RB />!
-  </span>,
-  <span key="line16">
-    <Indent />
-    <Indent />
-    <LAF />
-    <SN s="tag">div</SN>
-    <RA />
-  </span>,
-  <span key="line17">
-    <Indent />
-    <RP />
-  </span>,
-  <span key="line18">
-    <RB />
-    <SN s="punctuation.delimiter">;</SN>
-  </span>,
-  <span key="line19">
-    <SN s="keyword">class</SN>
-    <SP />
-    <SN s="type">
-      <Popup
-        style={{
-          color: cssVarStyleToken('error'),
-          backgroundColor: cssVarStyleToken('error.background'),
-          borderColor: cssVarStyleToken('error.border'),
-        }}
-        content="'Test' is declared but never used."
-      >
-        <span
-          style={{
-            textDecorationLine: 'underline',
-            textDecorationStyle: 'wavy',
-            textDecorationColor: cssVarStyleToken('error'),
-          }}
-        >
-          Test
-        </span>
-      </Popup>
-    </SN>
-    <SP />
-    <LB />
-  </span>,
-  <span key="line20">
-    <Indent />
-    <SN s="keyword">private</SN>
-    <SP />
-    <SN s="keyword">readonly</SN>
-    <SP />
-    <SN s="variable">name</SN>
-    <SN s="punctuation.delimiter">:</SN>
-    <SP />
-    <SN s="type">string</SN>
-    <SN s="punctuation.delimiter">;</SN>
-  </span>,
-  <span key="line21">
-    <Indent />
-    <SN s="function.method">constructor</SN>
-    <LP />
-    <SN s="variable">name</SN>
-    <SN s="punctuation.delimiter">:</SN>
-    <SP />
-    <SN s="type">string</SN>
-    <RP />
-    <SP />
-    <SN s="type">void</SN>
-    <SP />
-    <LB />
-  </span>,
-  <span key="line22">
-    <Indent />
-    <Indent />
-    <SN s="variable.special">this</SN>
-    <SN s="punctuation.delimiter">.</SN>
-    <SN s="variable">name</SN>
-    <SN s="punctuation.delimiter">;</SN>
-  </span>,
-  <span key="line23">
-    <Indent />
-    <RB />
-  </span>,
-  '',
-  <span key="line24">
-    <Indent />
-    <SN s="constructor">@guard</SN>
-    <LP />
-    <LB />
-    <SP />
-    <SN s="property">description</SN>
-    <SN s="punctuation.delimiter">:</SN>
-    <SP />
-    <SN s="string">&#39;Gets name&#39;</SN>
-    <SP />
-    <RB />
-    <RP />
-  </span>,
-  <span key="line25">
-    <Indent />
-    <SN s="keyword">public</SN>
-    <SP />
-    <SN s="function.method">getName</SN>
-    <LP />
-    <RP />
-    <SP />
-    <LB />
-  </span>,
-  <span key="line26">
-    <Indent />
-    <Indent />
-    <SN s="keyword">return</SN>
-    <SP />
-    <SN s="variable.special">this</SN>
-    <SN s="punctuation.delimiter">.</SN>
-    <SN s="variable">name</SN>
-    <SN s="punctuation.delimiter">;</SN>
-  </span>,
-  <span key="line27">
-    <Indent />
-    <RB />
-  </span>,
-  <span key="line28">
-    <RB />
-  </span>,
-  '',
-];
+export const SP = () => <span>&nbsp;</span>;
+export const Indent = ({ level }: { level?: number | undefined }) => {
+  return (
+    <>
+      {/* repeat (level * 2) times */}
+      {[...Array((level || 1) * 2)].map((a, i) => (
+        <SP key={i} />
+      ))}
+    </>
+  );
+};
+export const LA = () => <SN s="operator">&#60;</SN>;
+export const LAF = () => <SN s="operator">&#60;&#47;</SN>;
+export const RA = () => <SN s="operator">&#62;</SN>;
+export const LB = () => <SN s="punctuation.bracket">&#123;</SN>;
+export const RB = () => <SN s="punctuation.bracket">&#125;</SN>;
+export const LP = () => <SN s="punctuation.bracket">&#40;</SN>;
+export const RP = () => <SN s="punctuation.bracket">&#41;</SN>;
+export const LSB = () => <SN s="punctuation.bracket">&#91;</SN>;
+export const RSB = () => <SN s="punctuation.bracket">&#93;</SN>;
 
 export function Code() {
   const [top, setTop] = useState(0);
+
+  const { language } = useLanguage();
 
   const onScroll = (e: UIEvent) => {
     const el = e.target as HTMLDivElement;
     setTop(Math.ceil((el.scrollTop / el.scrollHeight) * el.clientHeight));
   };
+
+  const data = languagePacks[language];
 
   return (
     <code
@@ -495,14 +99,14 @@ export function Code() {
         className="flex flex-1 flex-col overflow-y-scroll scrollbar-hide"
         onScroll={onScroll}
       >
-        <ScrollbarMakers lineCount={lines.length + EXTRA_LINES} />
+        <ScrollbarMakers lineCount={data.lines.length + EXTRA_LINES} />
         <div id="scrollbar" />
-        {lines.map((code, line) => (
+        {data.lines.map((code, line) => (
           <div
             key={`code-${line.toString()}`}
             className="relative mr-[14px] flex items-start"
             style={{
-              backgroundColor: line === ACTIVE_ROW ? cssVarStyleToken('editor.active_line.background') : undefined,
+              backgroundColor: line === data.activeRow ? cssVarStyleToken('editor.active_line.background') : undefined,
             }}
           >
             <div className="git min-w-[6px]">
@@ -512,10 +116,10 @@ export function Code() {
             <div
               className="line-number min-w-[25px] text-right"
               style={{
-                color: cssVarStyleToken(line === ACTIVE_ROW ? 'editor.active_line_number' : 'editor.line_number'),
+                color: cssVarStyleToken(line === data.activeRow ? 'editor.active_line_number' : 'editor.line_number'),
               }}
             >
-              {line <= lines.length ? line + 1 : ''}
+              {line <= data.lines.length ? line + 1 : ''}
             </div>
             <div className="code flex flex-1 pl-2">{code}</div>
           </div>

--- a/app/components/preview/components/Dock.tsx
+++ b/app/components/preview/components/Dock.tsx
@@ -1,50 +1,23 @@
-import CssIcon from '~/assets/icons/file_icons/css.svg?react';
-import FileIcon from '~/assets/icons/file_icons/file.svg?react';
-import FolderIcon from '~/assets/icons/file_icons/folder.svg?react';
-import FolderOpenIcon from '~/assets/icons/file_icons/folder_open.svg?react';
-import HtmlIcon from '~/assets/icons/file_icons/html.svg?react';
-import PackageIcon from '~/assets/icons/file_icons/package.svg?react';
-import PrettierIcon from '~/assets/icons/file_icons/prettier.svg?react';
-import TypescriptIcon from '~/assets/icons/file_icons/typescript.svg?react';
+import { languagePacks, useLanguage } from '~/providers/language';
 import { cssVarStyleToken } from '~/utils/cssVarTokens';
 
-const files = [
-  { Icon: FolderOpenIcon, name: 'zed', indent: 0 },
-  { Icon: FolderIcon, name: '.github', indent: 2 },
-  { Icon: FolderIcon, name: 'node_modules', indent: 2 },
-  { Icon: FolderOpenIcon, name: 'src', indent: 2 },
-  { Icon: FolderOpenIcon, name: 'components', indent: 4 },
-  { Icon: FileIcon, name: 'Button.tsx', indent: 6 },
-  { Icon: FolderOpenIcon, name: 'pages', indent: 4 },
-  { Icon: TypescriptIcon, name: 'Contact.tsx', indent: 6 },
-  { Icon: TypescriptIcon, name: 'Help.tsx', indent: 6 },
-  { Icon: CssIcon, name: 'Home.css', indent: 6 },
-  { Icon: TypescriptIcon, name: 'Home.tsx', indent: 6 },
-  { Icon: TypescriptIcon, name: 'App.tsx', indent: 4 },
-  { Icon: FileIcon, name: '.gitignore', indent: 2 },
-  { Icon: PrettierIcon, name: '.prettierrc', indent: 2 },
-  { Icon: HtmlIcon, name: 'index.html', indent: 2 },
-  { Icon: FileIcon, name: 'index.js', indent: 2 },
-  { Icon: PackageIcon, name: 'package.json', indent: 2 },
-  { Icon: FileIcon, name: 'package-lock.json', indent: 2 },
-  { Icon: FileIcon, name: 'tsconfig.json', indent: 2 },
-];
-
 export function Dock() {
+  const { language } = useLanguage();
+
   return (
     <ul
       id="editor-right"
-      className="min-w-[150px] list-none overflow-y-auto overflow-x-hidden"
+      className="min-w-[250px] list-none overflow-y-auto overflow-x-hidden"
       style={{
         backgroundColor: cssVarStyleToken('panel.background'),
       }}
     >
-      {files.map(({ Icon, name, indent }) => (
+      {languagePacks[language].files.map(({ Icon, name, indent, selected }) => (
         <li
           key={name}
           className="ghost-element-hover px-3"
           style={{
-            backgroundColor: name === 'App.tsx' ? cssVarStyleToken('ghost_element.selected') : undefined,
+            backgroundColor: selected ? cssVarStyleToken('ghost_element.selected') : undefined,
           }}
         >
           <div
@@ -57,7 +30,7 @@ export function Dock() {
             <span
               className="whitespace-nowrap"
               style={{
-                color: cssVarStyleToken(name === 'App.tsx' ? 'text' : 'text.muted'),
+                color: cssVarStyleToken(selected ? 'text' : 'text.muted'),
               }}
             >
               {name}

--- a/app/components/preview/components/Tabs.tsx
+++ b/app/components/preview/components/Tabs.tsx
@@ -4,10 +4,15 @@ import MaximizeIcon from '~/assets/icons/maximize.svg?react';
 import PlusIcon from '~/assets/icons/plus.svg?react';
 import SplitIcon from '~/assets/icons/split.svg?react';
 import XIcon from '~/assets/icons/x.svg?react';
+import { languagePacks, useLanguage } from '~/providers/language';
 import { cssVarStyleToken } from '~/utils/cssVarTokens';
 import { GhostButton } from './GhostButton';
 
 export function Tabs() {
+  const { language } = useLanguage();
+
+  const tabs = languagePacks[language].tabs;
+
   return (
     <div
       id="editor-tabs"
@@ -42,7 +47,7 @@ export function Tabs() {
             backgroundColor: cssVarStyleToken('tab.active_background'),
           }}
         >
-          <span>App.tsx</span>
+          <span>{tabs[0]}</span>
           <span className="text-xs" style={{ color: cssVarStyleToken('text.muted') }}>
             ~/src
           </span>
@@ -58,7 +63,7 @@ export function Tabs() {
             backgroundColor: cssVarStyleToken('tab.inactive_background'),
           }}
         >
-          <span>index.html</span>
+          <span>{tabs[1]}</span>
           <GhostButton hidden={true}>
             <XIcon width={12} height={12} style={{ color: cssVarStyleToken('text.muted') }} />
           </GhostButton>
@@ -71,7 +76,7 @@ export function Tabs() {
             backgroundColor: cssVarStyleToken('tab.inactive_background'),
           }}
         >
-          <span>package.json</span>
+          <span>{tabs[2]}</span>
           <GhostButton hidden={true}>
             <XIcon width={12} height={12} style={{ color: cssVarStyleToken('text.muted') }} />
           </GhostButton>

--- a/app/components/side/Side.tsx
+++ b/app/components/side/Side.tsx
@@ -1,5 +1,6 @@
 import { ColorSchemeToggle } from '~/components/ColorSchemeToggle';
 import { Select, SelectContent, SelectItem, SelectTrigger } from '~/components/ui/select';
+import { type Language, languages, useLanguage } from '~/providers/language';
 import { useTheme } from '~/providers/theme';
 import { debounce } from '~/utils/debounce';
 import { type StyleTokens, type SyntaxTokens, syntaxTokens } from '../../providers/tokens';
@@ -42,6 +43,8 @@ export function Side({ edit }: { edit: boolean }) {
     dispatch({ type: 'addTheme' });
   };
 
+  const { language, setLanguage } = useLanguage();
+
   return (
     <>
       <div className="flex h-full w-96 min-w-[250px] flex-col overflow-hidden border-r border-zinc-300 bg-zinc-100 dark:border-neutral-600 dark:bg-neutral-800">
@@ -64,6 +67,19 @@ export function Side({ edit }: { edit: boolean }) {
               {themeFamily?.themes.map(({ name }, i) => (
                 <SelectItem key={name} value={`${i}`}>
                   {name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Select onValueChange={setLanguage} value={language}>
+            <SelectTrigger className="flex-1">
+              <span className="whitespace-nowrap overflow-hidden text-ellipsis">{languages[language ?? 'tsx']}</span>
+            </SelectTrigger>
+            <SelectContent>
+              {Object.keys(languages).map((l) => (
+                <SelectItem key={l} value={l}>
+                  {languages[l as Language]}
                 </SelectItem>
               ))}
             </SelectContent>

--- a/app/language_packs/csharp_pack.tsx
+++ b/app/language_packs/csharp_pack.tsx
@@ -1,0 +1,474 @@
+import ReadmeIcon from '~/assets/icons/file_icons/book.svg?react';
+import DatabaseIcon from '~/assets/icons/file_icons/database.svg?react';
+import FileIcon from '~/assets/icons/file_icons/file.svg?react';
+import FolderIcon from '~/assets/icons/file_icons/folder.svg?react';
+import FolderOpenIcon from '~/assets/icons/file_icons/folder_open.svg?react';
+import { Indent, LA, LB, LP, LSB, RA, RB, RP, RSB, SN, SP } from '~/components/preview/components/Code';
+import type { LanguagePack } from '~/providers/language';
+import { cssVarStyleToken, cssVarSyntaxColorToken } from '~/utils/cssVarTokens';
+
+let counter = 1;
+const key = () => counter++;
+
+export const csharpPack: LanguagePack = {
+  activeRow: 14,
+  tabs: ['UserService.cs', 'Program.cs', 'User.cs'],
+  files: [
+    { Icon: FolderOpenIcon, name: 'zed', indent: 0 },
+    { Icon: FolderIcon, name: '.github', indent: 2 },
+    { Icon: FolderIcon, name: 'build', indent: 2 },
+    { Icon: FolderOpenIcon, name: 'src', indent: 2 },
+    { Icon: FolderOpenIcon, name: 'Identity.API', indent: 4 },
+    { Icon: FolderIcon, name: 'bin', indent: 6 },
+    { Icon: FolderIcon, name: 'Validations', indent: 6 },
+    { Icon: FolderIcon, name: 'obj', indent: 6 },
+    { Icon: FolderIcon, name: 'Services', indent: 6 },
+    { Icon: FileIcon, name: 'UserService.cs', indent: 8, selected: true },
+    { Icon: DatabaseIcon, name: 'appsettings.json', indent: 6 },
+    { Icon: FileIcon, name: 'Identity.csproj', indent: 6 },
+    { Icon: FileIcon, name: 'GlobalUsings.cs', indent: 6 },
+    { Icon: FileIcon, name: 'Program.cs', indent: 6 },
+    { Icon: FolderOpenIcon, name: 'tests', indent: 2 },
+    { Icon: FolderIcon, name: 'Identity.UnitTests', indent: 4 },
+    { Icon: FileIcon, name: '.gitignore', indent: 2 },
+    { Icon: FileIcon, name: 'app.sln', indent: 2 },
+    { Icon: ReadmeIcon, name: 'README.md', indent: 2 },
+  ],
+  breadcrumbs: [
+    <div className="text-md" key={key()} style={{ color: cssVarStyleToken('text.muted') }}>
+      src/Identity.API/Services/UserService.cs
+    </div>,
+    <span className="text-xs" key={key()} style={{ color: cssVarStyleToken('text.muted') }}>
+      &gt;
+    </span>,
+    <span className="text-md pr-1" key={key()} style={{ color: cssVarSyntaxColorToken('keyword') }}>
+      class
+    </span>,
+    <span key={key()}>
+      <span className="text-md" style={{ color: cssVarSyntaxColorToken('type') }}>
+        UserService
+      </span>
+      <span
+        className="text-md"
+        style={{
+          color: cssVarSyntaxColorToken('punctuation.bracket'),
+        }}
+      />
+    </span>,
+  ],
+  lines: [
+    <div key={key()}>
+      <span
+        style={{
+          textDecorationColor: cssVarStyleToken('error'),
+        }}
+      >
+        <SN s="keyword">using</SN>
+        <SP />
+        <SN s="editor.foreground">System</SN>
+        <SN s="punctuation">.</SN>
+        <SN s="editor.foreground">Diagnostics</SN>
+        <SN s="punctuation">.</SN>
+        <SN s="editor.foreground">CodeAnalysis</SN>
+        <SN s="punctuation">;</SN>
+      </span>
+    </div>,
+    '',
+    <span key={key()}>
+      <SN s="keyword">public</SN>
+      <SP />
+      <SN s="keyword">class</SN>
+      <SP />
+      <SN s="type">UserService</SN>
+      <SP />
+      <SN s="punctuation.delimiter">:</SN>
+      <SP />
+      <SN s="type">IUserService</SN>
+      <SP />
+    </span>,
+    <span key={key()}>
+      <LB />
+    </span>,
+    <span key={key()}>
+      <Indent level={2} />
+      <SN s="keyword">public</SN>
+      <SP />
+      <SN s="type">IEnumerable</SN>
+      <LA />
+      <SN s="type.builtin">string</SN>
+      <RA />
+      <SP />
+      <SN s="variable">Errors</SN>
+      <SP />
+      <LB />
+      <SP />
+      <SN s="keyword">get</SN>
+      <SN s="punctuation">;</SN>
+      <SP />
+      <SN s="keyword">set</SN>
+      <SN s="punctuation">;</SN>
+      <SP />
+      <RB />
+    </span>,
+    '',
+    <span key={key()}>
+      <Indent level={2} />
+      <SN s="keyword">public</SN>
+      <SP />
+      <SN s="constructor">UserService</SN>
+      <LP />
+      <SN s="variable">ILogger</SN>
+      <SP />
+      <SN s="variable">logger</SN>
+      <RP />
+      <SP />
+    </span>,
+    <span key={key()}>
+      <Indent level={2} />
+      <LB />
+    </span>,
+    <span key={key()}>
+      <Indent level={4} />
+      <SN s="variable">_logger</SN>
+      <SP />
+      <SN s="operator">=</SN>
+      <SP />
+      <SN s="variable">logger</SN>
+      <SN s="punctuation">;</SN>
+    </span>,
+    <span key={key()}>
+      <Indent level={2} />
+      <RB />
+    </span>,
+    '',
+    <span key={key()}>
+      <Indent level={2} />
+      <LSB />
+      <SN s="attribute">AllowAnonymous</SN>
+      <RSB />
+    </span>,
+    <span key={key()}>
+      <Indent level={2} />
+      <SN s="keyword">public</SN>
+      <SP />
+      <SN s="keyword">async</SN>
+      <SP />
+      <SN s="type">Task</SN>
+      <LA />
+      <SN s="type">User</SN>
+      <RA />
+      <SP />
+      <SN s="function">GetUser</SN>
+      <LP />
+      <SN s="type.builtin">string</SN>
+      <SP />
+      <SN s="variable">id</SN>
+      <RP />
+      <SP />
+    </span>,
+    <span key={key()}>
+      <Indent level={2} />
+      <LB />
+    </span>,
+    <span key={key()} className="flex">
+      <Indent level={4} />
+      <SN s="type.builtin">var</SN>
+      <SP />
+      <SN s="variable">uri</SN>
+      <SP />
+      <SN s="operator">=</SN>
+      <SP />
+      <SN s="editor.foreground">UriHelper</SN>
+      <SN s="punctuation">.</SN>
+      <SN s="function">CombineUri</SN>
+      <LP />
+      <SN s="editor.foreground">GlobalSetting</SN>
+      <SN s="punctuation">.</SN>
+      <SN s="editor.foreground">UserInfoEndpoint</SN>
+      <RP />
+      <SN s="punctuation">;</SN>
+      <span
+        className="blink h-full"
+        style={{
+          backgroundColor: cssVarStyleToken('text.accent'),
+          width: '2px',
+        }}
+      />
+    </span>,
+    '',
+    <span key={key()}>
+      <Indent level={4} />
+      <SN s="comment">{/* This is a single comment on a single line*/}</SN>
+    </span>,
+    <span key={key()}>
+      <Indent level={4} />
+      <SN s="type.builtin">var</SN>
+      <SP />
+      <SN s="variable">count</SN>
+      <SP />
+      <SN s="operator">=</SN>
+      <SP />
+      <SN s="number">256</SN>
+      <SN s="punctuation">;</SN>
+    </span>,
+    <span key={key()}>
+      <Indent level={4} />
+      <SN s="type.builtin">var</SN>
+      <SP />
+      <SN s="variable">userInfo</SN>
+      <SP />
+      <SN s="operator">=</SN>
+      <SP />
+      <SN s="keyword">await</SN>
+      <SP />
+      <SN s="editor.foreground">_requestProvider</SN>
+      <SN s="punctuation">.</SN>
+      <SN s="type">GetAsync</SN>
+      <LA />
+      <SN s="type">UserInfo</SN>
+      <RA />
+      <LP />
+      <SN s="editor.foreground">uri</SN>
+      <RP />
+      <SN s="punctuation">;</SN>
+    </span>,
+    <span key={key()}>
+      <Indent level={4} />
+      <SN s="type.builtin">var</SN>
+      <SP />
+      <SN s="variable">user</SN>
+      <SP />
+      <SN s="operator">=</SN>
+      <SP />
+      <SN s="editor.foreground">subject</SN>
+      <SN s="punctuation">.</SN>
+      <SN s="editor.foreground">Claims</SN>
+      <SN s="punctuation">.</SN>
+      <SN s="function">Where</SN>
+      <LP />
+      <SN s="variable">x</SN>
+      <SP />
+      <SN s="operator">=&gt;</SN>
+      <SP />
+      <SN s="variable">x</SN>
+      <SN s="boolean">.</SN>
+      <SN s="variable">Type</SN>
+      <SP />
+      <SN s="operator">==</SN>
+      <SP />
+      <SN s="string">"sub"</SN>
+      <RP />
+      <SN s="punctuation">.</SN>
+      <SN s="function">FirstOrDefault</SN>
+      <LP />
+      <RP />
+      <SN s="operator">?</SN>
+      <SN s="punctuation">.</SN>
+      <SN s="editor.foreground">Value</SN>
+      <SN s="punctuation">;</SN>
+    </span>,
+    '',
+    <span key={key()}>
+      <Indent level={4} />
+      <SN s="keyword">if</SN>
+      <SP />
+      <LP />
+      <SN s="variable">user</SN>
+      <SP />
+      <SN s="operator">==</SN>
+      <SP />
+      <SN s="constant">null</SN>
+      <RP />
+    </span>,
+    <span key={key()}>
+      <Indent level={4} />
+      <LB />
+    </span>,
+    <span key={key()}>
+      <Indent level={6} />
+      <SN s="editor.foreground">_logger</SN>
+      <SN s="punctuation">.</SN>
+      <SN s="function">LogInfo</SN>
+      <LP />
+      <SN s="string">
+        $"This is a
+        <SP />
+        <LB />
+      </SN>
+      <SN s="editor.foreground">id</SN>
+      <SN s="string">
+        <RB />
+        <SP />
+        generic error string with interpolated id.
+      </SN>
+      <RP />
+      <SN s="punctuation">;</SN>
+    </span>,
+    <span key={key()}>
+      <Indent level={6} />
+      <SN s="keyword">throw</SN>
+      <SP />
+      <SN s="keyword">new</SN>
+      <SP />
+      <SN s="type">NotFoundException</SN>
+      <LP />
+      <SN s="string">
+        $"This is a
+        <SP />
+        <LB />
+      </SN>
+      <SN s="editor.foreground">id</SN>
+      <SN s="string">
+        <RB />
+        <SP />
+        generic error.
+      </SN>
+      <RP />
+      <SN s="punctuation">;</SN>
+    </span>,
+    <span key={key()}>
+      <Indent level={4} />
+      <RB />
+    </span>,
+    '',
+    <span key={key()}>
+      <Indent level={4} />
+      <SN s="keyword">if</SN>
+      <SP />
+      <LP />
+      <SN s="editor.foreground">client</SN>
+      <SN s="punctuation">.</SN>
+      <SN s="editor.foreground">IdentityProviderRestrictions</SN>
+      <SP />
+      <SN s="operator">!=</SN>
+      <SP />
+      <SN s="constant">null</SN>
+      <SP />
+      <SN s="operator">&&</SN>
+      <SP />
+      <SN s="editor.foreground">client</SN>
+      <SN s="punctuation">.</SN>
+      <SN s="editor.foreground">IdentityProviderRestrictions</SN>
+      <SN s="punctuation">.</SN>
+      <SN s="function">Any</SN>
+      <LP />
+      <RP />
+      <RP />
+    </span>,
+    <span key={key()} className="flex">
+      <Indent level={4} />
+      <LB />
+    </span>,
+    <span key={key()} className="flex">
+      <Indent level={6} />
+      <SN s="variable">providers</SN>
+      <SP />
+      <SN s="operator">=</SN>
+      <SP />
+      <SN s="editor.foreground">providers</SN>
+    </span>,
+    <span key={key()}>
+      <Indent level={8} />
+      <SN s="punctuation">.</SN>
+      <SN s="function">Where</SN>
+      <LP />
+      <SN s="variable">provider</SN>
+      <SP />
+      <SN s="operator">=&gt;</SN>
+      <SP />
+      <SN s="variable">client</SN>
+    </span>,
+    <span key={key()}>
+      <Indent level={10} />
+      <SN s="punctuation">.</SN>
+      <SN s="variable">IdentityProviderRestrictions</SN>
+    </span>,
+    <span key={key()}>
+      <Indent level={10} />
+      <SN s="punctuation">.</SN>
+      <SN s="function">Contains</SN>
+      <LP />
+      <SN s="variable">provider</SN>
+      <SN s="punctuation">.</SN>
+      <SN s="variable">AuthenticationScheme</SN>
+      <RP />
+    </span>,
+    <span key={key()}>
+      <Indent level={6} />
+      <RP />
+    </span>,
+    <span key={key()}>
+      <Indent level={6} />
+      <SN s="punctuation">.</SN>
+      <SN s="function">ToList</SN>
+      <LP />
+      <RP />
+      <SN s="punctuation">;</SN>
+    </span>,
+    <span key={key()}>
+      <Indent level={4} />
+      <RB />
+    </span>,
+    '',
+    <span key={key()}>
+      <Indent level={4} />
+      <SN s="keyword">if</SN>
+      <SP />
+      <LP />
+      <SN s="editor.foreground">providers</SN>
+      <SN s="punctuation">.</SN>
+      <SN s="editor.foreground">Length</SN>
+      <SP />
+      <SN s="operator">!=</SN>
+      <SP />
+      <SN s="number">0</SN>
+      <RP />
+    </span>,
+    <span key={key()}>
+      <Indent level={4} />
+      <LB />
+    </span>,
+    <span key={key()}>
+      <Indent level={6} />
+      <SN s="editor.foreground">CryptographyBuffer</SN>
+      <SN s="punctuation">.</SN>
+      <SN s="function">CopyToByteArray</SN>
+      <LP />
+      <SN s="editor.foreground">challengeBuffer</SN>
+      <SN s="punctuation">,</SN>
+      <SP />
+      <SN s="keyword">out</SN>
+      <SP />
+      <SN s="type.builtin">byte</SN>
+      <LSB />
+      <RSB />
+      <SP />
+      <SN s="editor.foreground">challengeBytes</SN>
+      <RP />
+      <SN s="punctuation">;</SN>
+    </span>,
+    <span key={key()}>
+      <Indent level={6} />
+      <SN s="keyword">return</SN>
+      <SP />
+      <SN s="keyword">new</SN>
+      <SP />
+      <SN s="type">User</SN>
+      <LP />
+      <SN s="editor.foreground">challengeBytes</SN>
+      <RP />
+      <SN s="punctuation">;</SN>
+    </span>,
+    <span key={key()}>
+      <Indent level={4} />
+      <RB />
+    </span>,
+    <span key={key()}>
+      <Indent level={2} />
+      <RB />
+    </span>,
+    <span key={key()}>
+      <RB />
+    </span>,
+  ],
+};

--- a/app/language_packs/csharp_pack.tsx
+++ b/app/language_packs/csharp_pack.tsx
@@ -198,7 +198,7 @@ export const csharpPack: LanguagePack = {
     '',
     <span key={key()}>
       <Indent level={4} />
-      <SN s="comment">{/* This is a single comment on a single line*/}</SN>
+      <SN s="comment">&#47;&#47; This is a single comment on a single line</SN>
     </span>,
     <span key={key()}>
       <Indent level={4} />

--- a/app/language_packs/tsx_pack.tsx
+++ b/app/language_packs/tsx_pack.tsx
@@ -1,0 +1,468 @@
+import CssIcon from '~/assets/icons/file_icons/css.svg?react';
+import FileIcon from '~/assets/icons/file_icons/file.svg?react';
+import FolderIcon from '~/assets/icons/file_icons/folder.svg?react';
+import FolderOpenIcon from '~/assets/icons/file_icons/folder_open.svg?react';
+import HtmlIcon from '~/assets/icons/file_icons/html.svg?react';
+import PackageIcon from '~/assets/icons/file_icons/package.svg?react';
+import PrettierIcon from '~/assets/icons/file_icons/prettier.svg?react';
+import TypescriptIcon from '~/assets/icons/file_icons/typescript.svg?react';
+import { Indent, LA, LAF, LB, LP, Popup, RA, RB, RP, SN, SP } from '~/components/preview/components/Code';
+import type { LanguagePack } from '~/providers/language';
+import { cssVarStyleToken, cssVarSyntaxColorToken } from '~/utils/cssVarTokens';
+
+let counter = 0;
+const key = () => counter++;
+
+export const tsxPack: LanguagePack = {
+  activeRow: 11,
+  tabs: ['App.tsx', 'index.html', 'package.json'],
+  files: [
+    { Icon: FolderOpenIcon, name: 'zed', indent: 0 },
+    { Icon: FolderIcon, name: '.github', indent: 2 },
+    { Icon: FolderIcon, name: 'node_modules', indent: 2 },
+    { Icon: FolderOpenIcon, name: 'src', indent: 2 },
+    { Icon: FolderOpenIcon, name: 'components', indent: 4 },
+    { Icon: FileIcon, name: 'Button.tsx', indent: 6 },
+    { Icon: FolderOpenIcon, name: 'pages', indent: 4 },
+    { Icon: TypescriptIcon, name: 'Contact.tsx', indent: 6 },
+    { Icon: TypescriptIcon, name: 'Help.tsx', indent: 6 },
+    { Icon: CssIcon, name: 'Home.css', indent: 6 },
+    { Icon: TypescriptIcon, name: 'Home.tsx', indent: 6 },
+    { Icon: TypescriptIcon, name: 'App.tsx', indent: 4, selected: true },
+    { Icon: FileIcon, name: '.gitignore', indent: 2 },
+    { Icon: PrettierIcon, name: '.prettierrc', indent: 2 },
+    { Icon: HtmlIcon, name: 'index.html', indent: 2 },
+    { Icon: FileIcon, name: 'index.js', indent: 2 },
+    { Icon: PackageIcon, name: 'package.json', indent: 2 },
+    { Icon: FileIcon, name: 'package-lock.json', indent: 2 },
+    { Icon: FileIcon, name: 'tsconfig.json', indent: 2 },
+  ],
+  breadcrumbs: [
+    <div className="text-md" key={key()} style={{ color: cssVarStyleToken('text.muted') }}>
+      src/pages/Home.tsx
+    </div>,
+    <span className="text-xs" key={key()} style={{ color: cssVarStyleToken('text.muted') }}>
+      &gt;
+    </span>,
+    <span className="text-md pr-1" key={key()} style={{ color: cssVarSyntaxColorToken('keyword') }}>
+      function
+    </span>,
+    <span key={key()}>
+      <span className="text-md" style={{ color: cssVarSyntaxColorToken('type') }}>
+        App
+      </span>
+      <span
+        className="text-md"
+        style={{
+          color: cssVarSyntaxColorToken('punctuation.bracket'),
+        }}
+      >
+        ()
+      </span>
+    </span>,
+  ],
+  lines: [
+    <div key="line1">
+      <span
+        style={{
+          textDecorationLine: 'underline',
+          textDecorationStyle: 'wavy',
+          textDecorationColor: cssVarStyleToken('error'),
+        }}
+      >
+        <SN s="keyword">import</SN>
+        <SP />
+        <SN s="variable">fs</SN>
+        <SP />
+        <SN s="keyword">from</SN>
+        <SP />
+        <SN s="string">&#34;fs&#34;</SN>
+        <SN s="punctuation.delimiter">;</SN>
+      </span>
+      <br />
+      <span
+        style={{
+          color: cssVarStyleToken('error'),
+        }}
+      >
+        &#39;fs&#39; is declared but its value is never read.
+      </span>
+    </div>,
+    <SN key="line2" s="comment">
+      &#47;&#47; simple comment
+    </SN>,
+    <SN key="line3" s="comment.doc">
+      &#47;** @param &#123;string&#125; a block comment **&#47;
+    </SN>,
+    <span key="line4">
+      <SN s="keyword">type</SN>
+      <SP />
+      <SN s="type">Prop</SN>
+      <SP />
+      <SN s="operator">=</SN>
+      <SP />
+      <LB />
+      <SP />
+      <SN s="property">a</SN>
+      <SN s="punctuation.delimiter">;</SN>
+      <SP />
+      <SN s="type">boolean</SN>
+      <SN s="punctuation.delimiter">;</SN>
+      <SP />
+      <SN s="property">b</SN>
+      <SN s="punctuation.delimiter">:</SN>
+      <SP />
+      <SN s="constant">null</SN>
+      <SN s="punctuation.delimiter">;</SN>
+      <SP />
+      <SN s="property">c</SN>
+      <SN s="punctuation.delimiter">:</SN>
+      <SP />
+      <SN s="type">string</SN>
+      <SP />
+      <RB />
+      <SN s="punctuation.delimiter">;</SN>
+    </span>,
+    <span key="line5">
+      <SN s="keyword">enum</SN>
+      <SP />
+      <SN s="type">
+        <Popup
+          style={{
+            color: cssVarStyleToken('error'),
+            backgroundColor: cssVarStyleToken('error.background'),
+            borderColor: cssVarStyleToken('error.border'),
+          }}
+          content="'Enum' is declared but never used."
+        >
+          <span
+            style={{
+              textDecorationLine: 'underline',
+              textDecorationStyle: 'wavy',
+              textDecorationColor: cssVarStyleToken('error'),
+            }}
+          >
+            Enum
+          </span>
+        </Popup>
+      </SN>
+      <SP />
+      <LB />
+      <SP />
+      <SN s="property">zed</SN>
+      <SP />
+      <SN s="operator">=</SN>
+      <SP />
+      <SN s="string">&#39;zed&#39;</SN>
+      <SP />
+      <RB />
+    </span>,
+    <span key="line6">
+      <SN s="keyword">const</SN>
+      <SP />
+      <SN s="variable">number</SN>
+      <SP />
+      <SN s="operator">=</SN>
+      <SP />
+      <SN s="number">1</SN>
+      <SN s="punctuation.delimiter">;</SN>
+    </span>,
+    <span key="line7">
+      <SN s="keyword">const</SN>
+      <SP />
+      <SN s="variable">string</SN>
+      <SP />
+      <SN s="operator">=</SN>
+      <SP />
+      <Popup
+        style={{
+          color: cssVarStyleToken('warning'),
+          backgroundColor: cssVarStyleToken('warning.background'),
+          borderColor: cssVarStyleToken('warning.border'),
+        }}
+        content={'Typo in the word "strig"'}
+      >
+        <span
+          style={{
+            textDecorationLine: 'underline',
+            textDecorationStyle: 'wavy',
+            textDecorationColor: cssVarStyleToken('warning'),
+          }}
+        >
+          <SN s="string">&#34;strig&#34;</SN>
+        </span>
+      </Popup>
+
+      <SN s="punctuation.delimiter">;</SN>
+    </span>,
+    <span key="line8">
+      <SN s="keyword">const</SN>
+      <SP />
+      <SN s="variable">boolean</SN>
+      <SP />
+      <SN s="operator">=</SN>
+      <SP />
+      <SN s="boolean">true</SN>
+      <SN s="punctuation.delimiter">;</SN>
+    </span>,
+    <span key="line9">
+      <SN s="keyword">const</SN>
+      <SP />
+      <SN s="variable">object</SN>
+      <SP />
+      <SN s="operator">=</SN>
+      <SP />
+      <LB />
+      <SP />
+      <SN s="property">id</SN>
+      <SN s="punctuation.delimiter">:</SN>
+      <SP />
+      <SN s="string">`</SN>
+      <SN s="punctuation.special">$&#123;</SN>
+      <SN s="variable">string</SN>
+      <SN s="punctuation.special">&#125;</SN>
+      <SN s="string">_id1`</SN>
+      <SP />
+      <RB />
+      <SP />
+      <SN s="punctuation.delimiter">;</SN>
+    </span>,
+    <span key="line10">
+      <SN s="keyword">const</SN>
+      <SP />
+      <SN s="variable">regex</SN>
+      <SP />
+      <SN s="operator">=</SN>
+      <SP />
+      <SN s="operator">/</SN>
+      <SN s="string.regex">(L^\d]string).*</SN>
+      <SN s="operator">/</SN>
+      <SN s="string.regex">i</SN>
+      <SN s="punctuation.delimiter">;</SN>
+    </span>,
+    <span key="line11" className="flex">
+      <SN s="keyword">export</SN>
+      <SP />
+      <SN s="keyword">default</SN>
+      <SP />
+      <SN s="keyword">function</SN>
+      <SP />
+      <SN s="type">App</SN>
+      <SN s="keyword">
+        <LA />
+      </SN>
+      <SN s="type">T</SN>
+      <SP />
+      <SN s="keyword">extends</SN>
+      <SP />
+      <SN s="type">Prop</SN>
+      <SP />
+      <SN s="operator">=</SN>
+      <SP />
+      <SN s="type">object</SN>
+      <SN s="keyword">
+        <RA />
+      </SN>
+      <LP />
+      <SN s="variable">p</SN>
+      <SN s="punctuation.delimiter">:</SN>
+      <SP />
+      <SN s="type">T</SN>
+      <RP />
+      <SN s="punctuation.delimiter">:</SN>
+      <SP />
+      <SN s="type">any</SN>
+      <SP />
+      <LB />
+      <SP />
+      <span
+        className="blink h-full"
+        style={{
+          backgroundColor: cssVarStyleToken('text.accent'),
+          width: '2px',
+        }}
+      />
+    </span>,
+    <span key="line12">
+      <Indent />
+      <SN s="keyword">if</SN>
+      <SP />
+      <LP />
+      <SN s="variable">p</SN>
+      <SP />
+      <SN s="operator">==</SN>
+      <SP />
+      <SN s="boolean">true</SN>
+      <RP />
+      <SP />
+      <SN s="keyword">return</SN>
+      <SP />
+      <SN s="constant">null</SN>
+      <SN s="punctuation.delimiter">;</SN>
+    </span>,
+    <span key="line13">
+      <Indent />
+      <SN s="keyword">return</SN>
+      <SP />
+      <LP />
+    </span>,
+    <span key="line14">
+      <Indent />
+      <Indent />
+      <LA />
+      <SN s="tag">div</SN>
+      <SP />
+      <SN s="attribute">className</SN>
+      <SN s="keyword">=</SN>
+      <SN s="string">&#34;class1&#34;</SN>
+      <SP />
+      <SN s="attribute">style</SN>
+      <SN s="keyword">=</SN>
+      <LB />
+      <LB />
+      <SP />
+      <SN s="property">test</SN>
+      <SN s="punctuation.delimiter">:</SN>
+      <SP />
+      <SN s="number">1</SN>
+      <SP />
+      <RB />
+      <RB />
+      <RA />
+    </span>,
+    <span key="line15">
+      <Indent />
+      <Indent />
+      <Indent />
+      hello world
+      <SP />
+      <LB />
+      <SN s="variable">p</SN>
+      <SN s="punctuation.delimiter">.</SN>
+      <SN s="property">name</SN>
+      <RB />!
+    </span>,
+    <span key="line16">
+      <Indent />
+      <Indent />
+      <LAF />
+      <SN s="tag">div</SN>
+      <RA />
+    </span>,
+    <span key="line17">
+      <Indent />
+      <RP />
+    </span>,
+    <span key="line18">
+      <RB />
+      <SN s="punctuation.delimiter">;</SN>
+    </span>,
+    <span key="line19">
+      <SN s="keyword">class</SN>
+      <SP />
+      <SN s="type">
+        <Popup
+          style={{
+            color: cssVarStyleToken('error'),
+            backgroundColor: cssVarStyleToken('error.background'),
+            borderColor: cssVarStyleToken('error.border'),
+          }}
+          content="'Test' is declared but never used."
+        >
+          <span
+            style={{
+              textDecorationLine: 'underline',
+              textDecorationStyle: 'wavy',
+              textDecorationColor: cssVarStyleToken('error'),
+            }}
+          >
+            Test
+          </span>
+        </Popup>
+      </SN>
+      <SP />
+      <LB />
+    </span>,
+    <span key="line20">
+      <Indent />
+      <SN s="keyword">private</SN>
+      <SP />
+      <SN s="keyword">readonly</SN>
+      <SP />
+      <SN s="variable">name</SN>
+      <SN s="punctuation.delimiter">:</SN>
+      <SP />
+      <SN s="type">string</SN>
+      <SN s="punctuation.delimiter">;</SN>
+    </span>,
+    <span key="line21">
+      <Indent />
+      <SN s="function.method">constructor</SN>
+      <LP />
+      <SN s="variable">name</SN>
+      <SN s="punctuation.delimiter">:</SN>
+      <SP />
+      <SN s="type">string</SN>
+      <RP />
+      <SP />
+      <SN s="type">void</SN>
+      <SP />
+      <LB />
+    </span>,
+    <span key="line22">
+      <Indent />
+      <Indent />
+      <SN s="variable.special">this</SN>
+      <SN s="punctuation.delimiter">.</SN>
+      <SN s="variable">name</SN>
+      <SN s="punctuation.delimiter">;</SN>
+    </span>,
+    <span key="line23">
+      <Indent />
+      <RB />
+    </span>,
+    '',
+    <span key="line24">
+      <Indent />
+      <SN s="constructor">@guard</SN>
+      <LP />
+      <LB />
+      <SP />
+      <SN s="property">description</SN>
+      <SN s="punctuation.delimiter">:</SN>
+      <SP />
+      <SN s="string">&#39;Gets name&#39;</SN>
+      <SP />
+      <RB />
+      <RP />
+    </span>,
+    <span key="line25">
+      <Indent />
+      <SN s="keyword">public</SN>
+      <SP />
+      <SN s="function.method">getName</SN>
+      <LP />
+      <RP />
+      <SP />
+      <LB />
+    </span>,
+    <span key="line26">
+      <Indent />
+      <Indent />
+      <SN s="keyword">return</SN>
+      <SP />
+      <SN s="variable.special">this</SN>
+      <SN s="punctuation.delimiter">.</SN>
+      <SN s="variable">name</SN>
+      <SN s="punctuation.delimiter">;</SN>
+    </span>,
+    <span key="line27">
+      <Indent />
+      <RB />
+    </span>,
+    <span key="line28">
+      <RB />
+    </span>,
+    '',
+  ],
+};

--- a/app/providers/language.tsx
+++ b/app/providers/language.tsx
@@ -1,0 +1,68 @@
+import { useFetcher } from '@remix-run/react';
+import type React from 'react';
+import { type ReactNode, createContext, useCallback, useContext, useState } from 'react';
+import type FileIcon from '~/assets/icons/file_icons/file.svg?react';
+import { csharpPack } from '~/language_packs/csharp_pack';
+import { tsxPack } from '~/language_packs/tsx_pack';
+
+export const languages = {
+  tsx: 'TSX',
+  csharp: 'C#',
+};
+export const languagePacks: Record<Language, LanguagePack> = {
+  tsx: tsxPack,
+  csharp: csharpPack,
+};
+
+export type Language = keyof typeof languages;
+export type LanguagePack = {
+  activeRow: number;
+  tabs: [string, string, string];
+  breadcrumbs: ReactNode[];
+  files: FileItem[];
+  lines: ReactNode[];
+};
+
+type FileItem = {
+  Icon: typeof FileIcon;
+  name: string;
+  indent: number;
+  selected?: boolean;
+};
+
+const languageCtx = createContext<{
+  language: Language;
+  setLanguage(theme: Language): void;
+}>({
+  language: 'tsx',
+  setLanguage: () => console.warn('Calling setLanguage provider beofre it is initialized!'),
+});
+
+export const useLanguage = () => useContext(languageCtx);
+
+function usePersistLanguage() {
+  const fetcher = useFetcher<{ language: Language }>({
+    key: 'language',
+  });
+
+  return (language: Language) => {
+    fetcher.submit({ language }, { action: '/action/language', method: 'post' });
+  };
+}
+
+export const LanguageProvider = (props: React.PropsWithChildren<{ language?: Language }>) => {
+  const persistLanguage = usePersistLanguage();
+  const [language, setLanguage] = useState<Language>(props.language ?? 'tsx');
+
+  const languageHandler = useCallback(
+    (language: Language) => {
+      setLanguage(language);
+      persistLanguage(language);
+    },
+    [persistLanguage],
+  );
+
+  return (
+    <languageCtx.Provider value={{ language, setLanguage: languageHandler }}>{props.children}</languageCtx.Provider>
+  );
+};

--- a/app/providers/tokens.ts
+++ b/app/providers/tokens.ts
@@ -157,6 +157,7 @@ export const miscTokens: StyleTokens[] = [];
 
 export const syntaxTokens = [
   'attribute',
+  'editor.foreground',
   'boolean',
   'comment',
   'comment.doc',
@@ -194,6 +195,7 @@ export const syntaxTokens = [
   'text.literal',
   'title',
   'type',
+  'type.builtin',
   'variable',
   'variable.special',
   'variant',

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -4,9 +4,11 @@ import { Toaster } from './components/ui/toaster';
 import { type ColorScheme, ColorSchemeProvider } from './providers/colorScheme';
 import { ThemeProvider } from './providers/theme';
 import { colorSchemeSession } from './utils/colorScheme.server';
+import { languageSession } from './utils/language.server';
 
 import './root.css';
 import './tailwind.css';
+import { type Language, LanguageProvider } from './providers/language';
 
 export const meta: MetaFunction = () => [
   { charset: 'utf-8' },
@@ -21,12 +23,18 @@ export const links: LinksFunction = () => [{ rel: 'manifest', href: '/manifest.j
 
 export type RootData = {
   colorScheme?: ColorScheme;
+  language?: Language;
   shareUrl?: string;
 };
 
 export const loader: LoaderFunction = async ({ request }) => {
-  const session = await colorSchemeSession(request);
-  return json({ colorScheme: session.getColorScheme() });
+  const _colorSchemeSession = await colorSchemeSession(request);
+  const _languageSession = await languageSession(request);
+
+  return json({
+    colorScheme: _colorSchemeSession.getColorScheme(),
+    language: _languageSession.getLanguage(),
+  });
 };
 
 export default function Root() {
@@ -41,9 +49,11 @@ export default function Root() {
       </head>
       <body className="bg-stone-300 dark:bg-stone-900">
         <ColorSchemeProvider colorScheme={loaderData.colorScheme}>
-          <ThemeProvider>
-            <Outlet />
-          </ThemeProvider>
+          <LanguageProvider language={loaderData.language}>
+            <ThemeProvider>
+              <Outlet />
+            </ThemeProvider>
+          </LanguageProvider>
         </ColorSchemeProvider>
         <ScrollRestoration />
         <Scripts />

--- a/app/routes/action.language.tsx
+++ b/app/routes/action.language.tsx
@@ -1,0 +1,17 @@
+import { type ActionFunction, json } from '@remix-run/cloudflare';
+import { type Language, languages } from '~/providers/language';
+import { languageSession } from '~/utils/language.server';
+
+export const action: ActionFunction = async ({ request }) => {
+  const session = await languageSession(request);
+  const requestText = await request.text();
+  const form = new URLSearchParams(requestText);
+  const language = form.get('language');
+
+  if (language != null && Object.keys(languages).includes(language)) {
+    session.setLanguage(language as Language);
+    return json({ language }, { headers: { 'Set-Cookie': await session.commit() } });
+  }
+
+  return language;
+};

--- a/app/utils/language.server.ts
+++ b/app/utils/language.server.ts
@@ -1,0 +1,23 @@
+import { createCookieSessionStorage } from '@remix-run/cloudflare';
+import type { Language } from '~/providers/language';
+
+const store = createCookieSessionStorage({
+  cookie: {
+    secure: true,
+    httpOnly: true,
+    name: 'language',
+    secrets: ['language-secret-key'],
+    sameSite: 'lax',
+    path: '/',
+  },
+});
+
+export async function languageSession(request: Request) {
+  const session = await store.getSession(request.headers.get('Cookie'));
+
+  return {
+    setLanguage: (language: Language) => session.set('language', language),
+    getLanguage: () => session.get('language') as Language | undefined,
+    commit: () => store.commitSession(session),
+  };
+}

--- a/biome.json
+++ b/biome.json
@@ -8,7 +8,12 @@
   },
   "linter": {
     "enabled": true,
-    "rules": { "recommended": true }
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noArrayIndexKey": "warn"
+      }
+    }
   },
   "formatter": {
     "enabled": true,


### PR DESCRIPTION
Hi, this PR adds a button to enable switching between different languages (PR includes C#). The original code sample remains unchanged.

Here is an image:
![image](https://github.com/user-attachments/assets/691e3801-e5ac-4d78-9030-0c3909148bd7)

and here is zed comparison:
![image](https://github.com/user-attachments/assets/a9db52bc-a447-42d1-8fae-8ecac20421e0)

The `useLanguage` works just like `useColorScheme`. In the code, the language specific things now live in their respective files (`csharpPack/tsxPack.tsx`). If u wanna add a new language, all u need to do is add an a new entry [here](https://github.com/labithiotis/zed-themes/compare/main...indexxd:zed-themes:lang-support?expand=1#diff-81a630d6131fa6e3af153d347ac70e6a21a735f5cca3a655e1aa6299996f1d5cR8) and then create a language pack.

I also changed the sizes a little bit (increased file explorer width and uncapped editor dimensions) to fit more code on the screen.