### PR TITLE
fix(Edit): w-64 when props 'edit' false

### DIFF
--- a/app/components/side/Side.tsx
+++ b/app/components/side/Side.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { IoBug } from 'react-icons/io5';
 import { Select, SelectContent, SelectItem, SelectTrigger } from '~/components/ui/select';
 import { useTheme } from '~/providers/theme';
+import { cn } from '~/utils';
 import { debounce } from '~/utils/debounce';
 import { type StyleTokens, type SyntaxTokens, syntaxTokens } from '../../providers/tokens';
 import type { AppearanceContent, HighlightStyleContent } from '../../themeFamily';
@@ -63,7 +64,12 @@ export function Side({ edit }: { edit: boolean }) {
   }, []);
 
   return (
-    <div className="flex h-full w-96 flex-col overflow-hidden border-r border-zinc-300 bg-zinc-100 dark:border-neutral-600 dark:bg-neutral-800">
+    <div
+      className={cn(
+        'flex h-full flex-col overflow-hidden border-r border-zinc-300 bg-zinc-100 dark:border-neutral-600 dark:bg-neutral-800',
+        { 'w-64': !edit },
+      )}
+    >
       {edit ? (
         <div className="flex flex-col gap-1.5 p-2">
           <div className="flex flex-col flex-1 gap-1">


### PR DESCRIPTION
Set width to Side component on not edit mode

[Запись экрана от 2024-10-23 17-55-48.webm](https://github.com/user-attachments/assets/d1f87579-457a-4e53-a3a0-1f499f8348ee)

And link to Clerk dev keys is 404(
https://github.com/clerkinc/clerk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced responsiveness of the Side component with dynamic width adjustments based on the edit state.
  
- **Bug Fixes**
	- Improved feedback capturing by ensuring feedback is only set when defined.

- **Style**
	- Updated styling logic for the main component to conditionally apply CSS classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->