### PR TITLE
Use Github API to sync themes instead of extension repo 

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -4,8 +4,6 @@ on:
   schedule:
     - cron: "0 8/12 * * *"
   workflow_dispatch:
-  push:
-    paths: [".github/workflows/sync.yml"]
 
 jobs:
   sync:
@@ -14,11 +12,6 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.PAT }}
-          repository: zed-industries/extensions
-          path: .tmp/zed-extensions
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:

--- a/dev/dbSeedThemes.json
+++ b/dev/dbSeedThemes.json
@@ -1,1297 +1,192 @@
 [
   {
-    "id": "0x96f",
-    "name": "0x96f-zed-theme",
-    "author": "Filip Janevski <filip@janevski.dev>",
-    "updatedDate": 1729516728000,
-    "versionHash": "6cab9a1",
+    "id": "catppuccin",
+    "name": "Catppuccin Themes",
+    "author": "Andrew Tec",
+    "updatedDate": 1725973141000,
+    "versionHash": "0.2.11",
     "bundled": true,
-    "repoUrl": "https://github.com/filipjanevski/zed-theme.git",
-    "repoStars": 5,
+    "repoUrl": "https://github.com/catppuccin/zed",
+    "repoStars": 255,
     "theme": {
       "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
-      "name": "0x96f-zed-theme",
-      "author": "Filip Janevski <filip@janevski.dev>",
+      "name": "Catppuccin",
+      "author": "Andrew Tec <andrewtec@enjoi.dev>",
       "themes": [
         {
-          "name": "0x96f Theme",
-          "appearance": "dark",
-          "style": {
-            "background.appearance": "opaque",
-            "border": "#101010",
-            "border.variant": "#101010",
-            "border.focused": "#101010",
-            "border.selected": "#101010",
-            "border.transparent": "#101010",
-            "border.disabled": "#101010",
-            "elevated_surface.background": "#2E2A2E",
-            "surface.background": "#545054",
-            "background": "#262427",
-            "element.background": "#262026",
-            "element.hover": "#424042",
-            "element.active": "#525052",
-            "element.selected": "#383438",
-            "element.disabled": "#8B8B8B",
-            "drop_target.background": "#383438DD",
-            "ghost_element.background": "#262026",
-            "ghost_element.hover": "#424042",
-            "ghost_element.active": "#525052",
-            "ghost_element.selected": "#383438",
-            "ghost_element.disabled": "#8B8B8B",
-            "text": "#FCFCFC",
-            "text.muted": "#BCBCBC",
-            "text.placeholder": "#A6A6A5",
-            "text.disabled": "#8B8B8B",
-            "text.accent": "#FCFCFC",
-            "icon": "#FCFCFC",
-            "icon.muted": "#A6A6A5",
-            "icon.disabled": "#8B8B8B",
-            "icon.placeholder": "#A6A6A5",
-            "icon.accent": "#FCFCFC",
-            "status_bar.background": "#1E1D1F",
-            "title_bar.background": "#1E1D1F",
-            "toolbar.background": "#252425",
-            "tab_bar.background": "#1E1D1F",
-            "tab.inactive_background": "#1E1D1F",
-            "tab.active_background": "#252425",
-            "search.match_background": "#686068",
-            "panel.background": "#1E1D1F",
-            "panel.focused_border": "#101010",
-            "pane.focused_border": "#101010",
-            "pane_group.border": "#101010",
-            "scrollbar.thumb.background": "#C1D9FF15",
-            "scrollbar.thumb.hover_background": "#C1D9FF30",
-            "scrollbar.thumb.border": "#C1D9FF15",
-            "scrollbar.track.background": "#262427",
-            "scrollbar.track.border": "#545452",
-            "editor.foreground": "#FCFCFC",
-            "editor.background": "#262427",
-            "editor.gutter.background": "#262427",
-            "editor.subheader.background": "#484447",
-            "editor.active_line.background": "#333032",
-            "editor.highlighted_line.background": "#484447",
-            "editor.line_number": "#A6A6A5",
-            "editor.active_line_number": "#FCFCFC",
-            "editor.invisible": "#8B8B8B",
-            "editor.wrap_guide": "#262427",
-            "editor.active_wrap_guide": "#262427",
-            "editor.document_highlight.read_background": null,
-            "editor.document_highlight.write_background": null,
-            "terminal.background": "#262427",
-            "terminal.foreground": "#FCFCFC",
-            "terminal.bright_foreground": "#FFFFFF",
-            "terminal.dim_foreground": "#FCFCFC",
-            "terminal.ansi.black": "#262427",
-            "terminal.ansi.bright_black": "#545452",
-            "terminal.ansi.dim_black": "#262427",
-            "terminal.ansi.red": "#FF7272",
-            "terminal.ansi.bright_red": "#FF8787",
-            "terminal.ansi.dim_red": "#FF7272",
-            "terminal.ansi.green": "#BCDF59",
-            "terminal.ansi.bright_green": "#C6E472",
-            "terminal.ansi.dim_green": "#BCDF59",
-            "terminal.ansi.yellow": "#FFCA58",
-            "terminal.ansi.bright_yellow": "#FFD271",
-            "terminal.ansi.dim_yellow": "#FFCA58",
-            "terminal.ansi.blue": "#49CAE4",
-            "terminal.ansi.bright_blue": "#64D2E8",
-            "terminal.ansi.dim_blue": "#49CAE4",
-            "terminal.ansi.magenta": "#A093E2",
-            "terminal.ansi.bright_magenta": "#AEA3E6",
-            "terminal.ansi.dim_magenta": "#A093E2",
-            "terminal.ansi.cyan": "#AEE8F4",
-            "terminal.ansi.bright_cyan": "#BAEBF6",
-            "terminal.ansi.dim_cyan": "#AEE8F4",
-            "terminal.ansi.white": "#FCFCFC",
-            "terminal.ansi.bright_white": "#FFFFFF",
-            "terminal.ansi.dim_white": "#FCFCFC",
-            "link_text.hover": "#49CAE4",
-            "conflict": "#FF7272",
-            "conflict.background": "#262427",
-            "conflict.border": "#FF7272",
-            "created": "#BCDF59",
-            "created.background": "#262427",
-            "created.border": "#BCDF59",
-            "deleted": "#FF7272",
-            "deleted.background": "#262427",
-            "deleted.border": "#FF7272",
-            "error": "#FF7272",
-            "error.background": "#262427",
-            "error.border": "#FF7272",
-            "hidden": "#4C4C4C",
-            "hidden.background": "#262427",
-            "hidden.border": "#4C4C4C",
-            "hint": "#51CDE7",
-            "hint.background": "#262427",
-            "hint.border": "#AEE8F4",
-            "ignored": "#7D7D7D",
-            "ignored.background": "#262427",
-            "ignored.border": "#7D7D7D",
-            "info": "#49CAE4",
-            "info.background": "#262427",
-            "info.border": "#49CAE4",
-            "modified": "#49CAE4",
-            "modified.background": "#262427",
-            "modified.border": "#49CAE4",
-            "predictive": "#8B8B8B",
-            "predictive.background": "#262427",
-            "predictive.border": "#8B8B8B",
-            "renamed": "#FFD271",
-            "renamed.background": "#262427",
-            "renamed.border": "#FFD271",
-            "success": "#C6E472",
-            "success.background": "#262427",
-            "success.border": "#C6E472",
-            "unreachable": "#4C4C4C",
-            "unreachable.background": "#262427",
-            "unreachable.border": "#4C4C4C",
-            "warning": "#FC9867",
-            "warning.background": "#262427",
-            "warning.border": "#FC9867",
-            "players": [
-              {
-                "cursor": "#FFBD3E",
-                "background": "#2C2A2E",
-                "selection": "#504650"
-              }
-            ],
-            "syntax": {
-              "attribute": {
-                "color": "#FC9867",
-                "font_style": null,
-                "font_weight": null
-              },
-              "boolean": {
-                "color": "#AEE8F4",
-                "font_style": null,
-                "font_weight": null
-              },
-              "comment": {
-                "color": "#8B8B8B",
-                "font_style": null,
-                "font_weight": null
-              },
-              "comment.doc": {
-                "color": "#8B8B8B",
-                "font_style": null,
-                "font_weight": null
-              },
-              "constant": {
-                "color": "#FC9867",
-                "font_style": null,
-                "font_weight": null
-              },
-              "constructor": {
-                "color": "#FF8787",
-                "font_style": null,
-                "font_weight": null
-              },
-              "emphasis": {
-                "color": "#FC9867",
-                "font_style": "italic",
-                "font_weight": null
-              },
-              "emphasis.strong": {
-                "color": "#FF8787",
-                "font_style": null,
-                "font_weight": 700
-              },
-              "function": {
-                "color": "#C6E472",
-                "font_style": null,
-                "font_weight": null
-              },
-              "keyword": {
-                "color": "#FF8787",
-                "font_style": null,
-                "font_weight": null
-              },
-              "link_text": {
-                "color": "#64D2E8",
-                "font_style": null,
-                "font_weight": null
-              },
-              "link_uri": {
-                "color": "#64D2E8",
-                "font_style": null,
-                "font_weight": null
-              },
-              "number": {
-                "color": "#AEA3E6",
-                "font_style": null,
-                "font_weight": null
-              },
-              "operator": {
-                "color": "#FCFCFC",
-                "font_style": null,
-                "font_weight": null
-              },
-              "property": {
-                "color": "#C6E472",
-                "font_style": null,
-                "font_weight": null
-              },
-              "punctuation": {
-                "color": "#FCFCFC",
-                "font_style": null,
-                "font_weight": null
-              },
-              "punctuation.bracket": {
-                "color": "#FCFCFC",
-                "font_style": null,
-                "font_weight": null
-              },
-              "punctuation.delimiter": {
-                "color": "#FCFCFC",
-                "font_style": null,
-                "font_weight": null
-              },
-              "punctuation.list_marker": {
-                "color": "#FCFCFC",
-                "font_style": null,
-                "font_weight": null
-              },
-              "punctuation.special": {
-                "color": "#FCFCFC",
-                "font_style": null,
-                "font_weight": null
-              },
-              "string": {
-                "color": "#FFD271",
-                "font_style": null,
-                "font_weight": null
-              },
-              "string.escape": {
-                "color": "#FFD271",
-                "font_style": null,
-                "font_weight": null
-              },
-              "string.regex": {
-                "color": "#FFD271",
-                "font_style": null,
-                "font_weight": null
-              },
-              "string.special": {
-                "color": "#FC9867",
-                "font_style": null,
-                "font_weight": null
-              },
-              "string.special.symbol": {
-                "color": "#FC9867",
-                "font_style": null,
-                "font_weight": null
-              },
-              "tag": {
-                "color": "#64D2E8",
-                "font_style": null,
-                "font_weight": null
-              },
-              "text.literal": {
-                "color": "#C6E472",
-                "font_style": null,
-                "font_weight": null
-              },
-              "type": {
-                "color": "#AEE8F4",
-                "font_style": null,
-                "font_weight": null
-              },
-              "variable": {
-                "color": "#FFD271",
-                "font_style": null,
-                "font_weight": null
-              },
-              "variable.special": {
-                "color": "#AEE8F4",
-                "font_style": null,
-                "font_weight": null
-              }
-            }
-          }
-        }
-      ]
-    },
-    "userId": null,
-    "installCount": 2067
-  },
-  {
-    "id": "adaltas-theme",
-    "name": "Adaltas Theme",
-    "author": "David Worms <david@adaltas.com>",
-    "updatedDate": 1727728232000,
-    "versionHash": "4f5256f",
-    "bundled": true,
-    "repoUrl": "https://github.com/adaltas/zed-adaltas-theme.git",
-    "repoStars": 0,
-    "theme": {
-      "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
-      "name": "Adaltas Theme",
-      "author": "David Worms <david@adaltas.com>",
-      "themes": [
-        {
-          "name": "Adaltas Dark",
-          "appearance": "dark",
-          "style": {
-            "border": "#3F495FFF",
-            "border.variant": "#59657EFF",
-            "border.focused": "#183934ff",
-            "border.selected": "#183934ff",
-            "border.transparent": "#00000000",
-            "border.disabled": "#292d37ff",
-            "elevated_surface.background": "#21242bff",
-            "surface.background": "#21242bff",
-            "background": "#262933ff",
-            "element.background": "#21242bff",
-            "element.hover": "#252931ff",
-            "element.active": "#2a2f39ff",
-            "element.selected": "#2a2f39ff",
-            "element.disabled": "#21242bff",
-            "drop_target.background": "#aca8ae80",
-            "ghost_element.background": "#00000000",
-            "ghost_element.hover": "#252931ff",
-            "ghost_element.active": "#2a2f39ff",
-            "ghost_element.selected": "#2a2f39ff",
-            "ghost_element.disabled": "#21242bff",
-            "text": "#F1EFE6FF",
-            "text.muted": "#D2E3EAFF",
-            "text.placeholder": "#6b6b73ff",
-            "text.disabled": "#6b6b73ff",
-            "text.accent": "#10a793ff",
-            "icon": "#f7f7f8ff",
-            "icon.muted": "#aca8aeff",
-            "icon.disabled": "#6b6b73ff",
-            "icon.placeholder": "#aca8aeff",
-            "icon.accent": "#10a793ff",
-            "status_bar.background": "#1D2028FF",
-            "title_bar.background": "#1D2028FF",
-            "title_bar.inactive_background": "#21242bff",
-            "toolbar.background": "#272F3EFF",
-            "tab_bar.background": "#1D2028FF",
-            "tab.inactive_background": "#232936FF",
-            "tab.active_background": "#354265FF",
-            "search.match_background": "#11A79366",
-            "panel.background": "#1D2028FF",
-            "panel.focused_border": null,
-            "pane.focused_border": null,
-            "scrollbar.thumb.background": "#f7f7f84c",
-            "scrollbar.thumb.hover_background": "#252931ff",
-            "scrollbar.thumb.border": "#252931ff",
-            "scrollbar.track.background": "#00000000",
-            "scrollbar.track.border": "#21232aff",
-            "editor.foreground": "#F1EFE6FF",
-            "editor.background": "#272F3EFF",
-            "editor.gutter.background": "#272F3EFF",
-            "editor.subheader.background": "#21242bff",
-            "editor.active_line.background": "#394256FF",
-            "editor.highlighted_line.background": "#21242bff",
-            "editor.line_number": "#f7f7f859",
-            "editor.active_line_number": "#f7f7f8ff",
-            "editor.invisible": "#64646dff",
-            "editor.wrap_guide": "#f7f7f80d",
-            "editor.active_wrap_guide": "#f7f7f81a",
-            "editor.document_highlight.read_background": "#10a7931a",
-            "editor.document_highlight.write_background": "#64646d66",
-            "terminal.background": "#232936FF",
-            "terminal.foreground": "#F7F7F8FF",
-            "terminal.bright_foreground": "#f7f7f8ff",
-            "terminal.dim_foreground": "#1e2025ff",
-            "terminal.ansi.black": "#E8E4CFFF",
-            "terminal.ansi.bright_black": "#989898FF",
-            "terminal.ansi.dim_black": "#f7f7f8ff",
-            "terminal.ansi.red": "#f82871ff",
-            "terminal.ansi.bright_red": "#8e0f3aff",
-            "terminal.ansi.dim_red": "#ffa3b5ff",
-            "terminal.ansi.green": "#96df71ff",
-            "terminal.ansi.bright_green": "#457c38ff",
-            "terminal.ansi.dim_green": "#cef0b9ff",
-            "terminal.ansi.yellow": "#fee56cff",
-            "terminal.ansi.bright_yellow": "#958334ff",
-            "terminal.ansi.dim_yellow": "#fef1b7ff",
-            "terminal.ansi.blue": "#10a793ff",
-            "terminal.ansi.bright_blue": "#1a5148ff",
-            "terminal.ansi.dim_blue": "#9cd4c7ff",
-            "terminal.ansi.magenta": "#c74cecff",
-            "terminal.ansi.bright_magenta": "#682681ff",
-            "terminal.ansi.dim_magenta": "#e7abf7ff",
-            "terminal.ansi.cyan": "#08e7c5ff",
-            "terminal.ansi.bright_cyan": "#008169ff",
-            "terminal.ansi.dim_cyan": "#a9f4e1ff",
-            "terminal.ansi.white": "#f7f7f8ff",
-            "terminal.ansi.bright_white": "#f7f7f8ff",
-            "terminal.ansi.dim_white": "#87858cff",
-            "link_text.hover": "#10a793ff",
-            "conflict": "#fee56cff",
-            "conflict.background": "#5c5014ff",
-            "conflict.border": "#796b26ff",
-            "created": "#62E6CAFF",
-            "created.background": "#184618ff",
-            "created.border": "#306129ff",
-            "deleted": "#f82871ff",
-            "deleted.background": "#54051bff",
-            "deleted.border": "#72092aff",
-            "error": "#f82871ff",
-            "error.background": "#54051bff",
-            "error.border": "#72092aff",
-            "hidden": "#6b6b73ff",
-            "hidden.background": "#262933ff",
-            "hidden.border": "#292d37ff",
-            "hint": "#618399ff",
-            "hint.background": "#12231fff",
-            "hint.border": "#183934ff",
-            "ignored": "#6b6b73ff",
-            "ignored.background": "#262933ff",
-            "ignored.border": "#2b2f38ff",
-            "info": "#10a793ff",
-            "info.background": "#12231fff",
-            "info.border": "#183934ff",
-            "modified": "#FFDD89FF",
-            "modified.background": "#5c5014ff",
-            "modified.border": "#796b26ff",
-            "predictive": "#315f70ff",
-            "predictive.background": "#184618ff",
-            "predictive.border": "#306129ff",
-            "renamed": "#10a793ff",
-            "renamed.background": "#12231fff",
-            "renamed.border": "#183934ff",
-            "success": "#96df71ff",
-            "success.background": "#184618ff",
-            "success.border": "#306129ff",
-            "unreachable": "#aca8aeff",
-            "unreachable.background": "#262933ff",
-            "unreachable.border": "#2b2f38ff",
-            "warning": "#fee56cff",
-            "warning.background": "#5c5014ff",
-            "warning.border": "#796b26ff",
-            "players": [
-              {
-                "cursor": "#10a793ff",
-                "background": "#10a793ff",
-                "selection": "#10a7933d"
-              },
-              {
-                "cursor": "#c74cecff",
-                "background": "#c74cecff",
-                "selection": "#c74cec3d"
-              },
-              {
-                "cursor": "#f29c14ff",
-                "background": "#f29c14ff",
-                "selection": "#f29c143d"
-              },
-              {
-                "cursor": "#893ea6ff",
-                "background": "#893ea6ff",
-                "selection": "#893ea63d"
-              },
-              {
-                "cursor": "#08e7c5ff",
-                "background": "#08e7c5ff",
-                "selection": "#08e7c53d"
-              },
-              {
-                "cursor": "#f82871ff",
-                "background": "#f82871ff",
-                "selection": "#f828713d"
-              },
-              {
-                "cursor": "#fee56cff",
-                "background": "#fee56cff",
-                "selection": "#fee56c3d"
-              },
-              {
-                "cursor": "#96df71ff",
-                "background": "#96df71ff",
-                "selection": "#96df713d"
-              }
-            ],
-            "syntax": {
-              "attribute": {
-                "color": "#E88DFFFF",
-                "font_style": null,
-                "font_weight": null
-              },
-              "boolean": {
-                "color": "#96df71ff",
-                "font_style": null,
-                "font_weight": null
-              },
-              "comment": {
-                "color": "#afabb1ff",
-                "font_style": null,
-                "font_weight": null
-              },
-              "comment.doc": {
-                "color": "#afabb1ff",
-                "font_style": null,
-                "font_weight": null
-              },
-              "constant": {
-                "color": "#59CDFFFF",
-                "font_style": null,
-                "font_weight": null
-              },
-              "constructor": {
-                "color": "#E88DFFFF",
-                "font_style": null,
-                "font_weight": null
-              },
-              "embedded": {
-                "color": "#f7f7f8ff",
-                "font_style": null,
-                "font_weight": null
-              },
-              "emphasis": {
-                "color": "#E88DFFFF",
-                "font_style": null,
-                "font_weight": null
-              },
-              "emphasis.strong": {
-                "color": "#E88DFFFF",
-                "font_style": null,
-                "font_weight": 700
-              },
-              "enum": {
-                "color": "#82FABDFF",
-                "font_style": null,
-                "font_weight": null
-              },
-              "function": {
-                "color": "#fee56cff",
-                "font_style": null,
-                "font_weight": null
-              },
-              "hint": {
-                "color": "#618399ff",
-                "font_style": null,
-                "font_weight": 700
-              },
-              "keyword": {
-                "color": "#E88DFFFF",
-                "font_style": null,
-                "font_weight": null
-              },
-              "label": {
-                "color": "#E88DFFFF",
-                "font_style": null,
-                "font_weight": null
-              },
-              "link_text": {
-                "color": "#82FABDFF",
-                "font_style": "italic",
-                "font_weight": null
-              },
-              "link_uri": {
-                "color": "#FF77A7FF",
-                "font_style": null,
-                "font_weight": null
-              },
-              "number": {
-                "color": "#96df71ff",
-                "font_style": null,
-                "font_weight": null
-              },
-              "operator": {
-                "color": "#E88DFFFF",
-                "font_style": null,
-                "font_weight": null
-              },
-              "predictive": {
-                "color": "#315f70ff",
-                "font_style": "italic",
-                "font_weight": null
-              },
-              "preproc": {
-                "color": "#f7f7f8ff",
-                "font_style": null,
-                "font_weight": null
-              },
-              "primary": {
-                "color": "#f7f7f8ff",
-                "font_style": null,
-                "font_weight": null
-              },
-              "property": {
-                "color": "#59CDFFFF",
-                "font_style": null,
-                "font_weight": null
-              },
-              "punctuation": {
-                "color": "#d8d5dbff",
-                "font_style": null,
-                "font_weight": null
-              },
-              "punctuation.bracket": {
-                "color": "#d8d5dbff",
-                "font_style": null,
-                "font_weight": null
-              },
-              "punctuation.delimiter": {
-                "color": "#d8d5dbff",
-                "font_style": null,
-                "font_weight": null
-              },
-              "punctuation.list_marker": {
-                "color": "#d8d5dbff",
-                "font_style": null,
-                "font_weight": null
-              },
-              "punctuation.special": {
-                "color": "#d8d5dbff",
-                "font_style": null,
-                "font_weight": null
-              },
-              "string": {
-                "color": "#82FABDFF",
-                "font_style": null,
-                "font_weight": null
-              },
-              "string.escape": {
-                "color": "#82FABDFF",
-                "font_style": null,
-                "font_weight": null
-              },
-              "string.regex": {
-                "color": "#82FABDFF",
-                "font_style": null,
-                "font_weight": null
-              },
-              "string.special": {
-                "color": "#82FABDFF",
-                "font_style": null,
-                "font_weight": null
-              },
-              "string.special.symbol": {
-                "color": "#82FABDFF",
-                "font_style": null,
-                "font_weight": null
-              },
-              "tag": {
-                "color": "#E88DFFFF",
-                "font_style": null,
-                "font_weight": null
-              },
-              "text.literal": {
-                "color": "#82FABDFF",
-                "font_style": null,
-                "font_weight": null
-              },
-              "title": {
-                "color": "#D59AFFFF",
-                "font_style": null,
-                "font_weight": 700
-              },
-              "type": {
-                "color": "#08e7c5ff",
-                "font_style": null,
-                "font_weight": null
-              },
-              "variable": {
-                "color": "#C4EDFFFF",
-                "font_style": null,
-                "font_weight": null
-              },
-              "variable.special": {
-                "color": "#C4EDFFFF",
-                "font_style": null,
-                "font_weight": null
-              },
-              "variant": {
-                "color": "#E88DFFFF",
-                "font_style": null,
-                "font_weight": null
-              }
-            }
-          }
-        }
-      ]
-    },
-    "userId": null,
-    "installCount": 220
-  },
-  {
-    "id": "adwaita-pastel",
-    "name": "Adwaita Pastel",
-    "author": "Benjamin Davies",
-    "updatedDate": 1724080788000,
-    "versionHash": "b9e415f",
-    "bundled": true,
-    "repoUrl": "https://github.com/Benjamin-Davies/zed-theme-adwaita.git",
-    "repoStars": 5,
-    "theme": {
-      "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
-      "name": "Adwaita Pastel",
-      "author": "Benjamin Davies",
-      "themes": [
-        {
-          "name": "Adwaita Pastel Dark",
-          "appearance": "dark",
-          "style": {
-            "border": "#4f4f4f",
-            "border.variant": "#4f4f4f",
-            "border.focused": "#1a5fb4",
-            "border.selected": "#1a5fb4",
-            "border.transparent": "#00000000",
-            "border.disabled": "#303030",
-            "elevated_surface.background": "#303030",
-            "surface.background": "#303030",
-            "background": "#1e1e1e",
-            "element.background": "#303030",
-            "element.hover": "#444444",
-            "element.active": "#444444",
-            "element.selected": "#444444",
-            "element.disabled": "#303030",
-            "drop_target.background": "#44444480",
-            "ghost_element.background": "#00000000",
-            "ghost_element.hover": "#444444",
-            "ghost_element.active": "#444444",
-            "ghost_element.selected": "#444444",
-            "ghost_element.disabled": "#303030",
-            "text": "#ffffff",
-            "text.muted": "#c7c7c7",
-            "text.placeholder": "#808080",
-            "text.disabled": "#808080",
-            "text.accent": "#808080",
-            "icon": "#ffffff",
-            "icon.muted": "#c7c7c7",
-            "icon.placeholder": "#808080",
-            "icon.disabled": "#808080",
-            "icon.accent": "#808080",
-            "status_bar.background": "#282828",
-            "title_bar.background": "#303030",
-            "title_bar.inactive_background": "#282828",
-            "toolbar.background": "#303030",
-            "tab_bar.background": "#303030",
-            "tab.inactive_background": "#303030",
-            "tab.active_background": "#444444",
-            "search.match_background": "#1a5fb466",
-            "panel.background": "#303030",
-            "panel.focused_border": null,
-            "pane.focused_border": null,
-            "scrollbar.thumb.background": "#ffffff33",
-            "scrollbar.thumb.hover_background": "#858585",
-            "scrollbar.thumb.border": "#151515",
-            "scrollbar.track.background": "#00000000",
-            "scrollbar.track.border": "#343434",
-            "editor.foreground": "#ffffff",
-            "editor.background": "#1e1e1e",
-            "editor.gutter.background": "#1e1e1e",
-            "editor.subheader.background": "#1e1e1e",
-            "editor.active_line.background": "#444444",
-            "editor.highlighted_line.background": "#444444",
-            "editor.line_number": "#808080",
-            "editor.line_number.active": "#c7c7c7",
-            "editor.invisible": "#808080",
-            "editor.wrap_guide": "#444444",
-            "editor.active_wrap_guide": "#444444",
-            "editor.document_highlight.read_background": "#3584e41a",
-            "editor.document_highlight.write_background": "#44444466",
-            "terminal.background": "#1e1e1e",
-            "terminal.foreground": "#ffffff",
-            "terminal.bright_foreground": "#ffffff",
-            "terminal.dim_foreground": "#ffffff",
-            "terminal.ansi.black": "#241f31",
-            "terminal.ansi.bright_black": "#5e5c64",
-            "terminal.ansi.dim_black": "#241f31",
-            "terminal.ansi.red": "#c01c28",
-            "terminal.ansi.bright_red": "#ed333b",
-            "terminal.ansi.dim_red": "#c01c28",
-            "terminal.ansi.green": "#2ec27e",
-            "terminal.ansi.bright_green": "#57e389",
-            "terminal.ansi.dim_green": "#2ec27e",
-            "terminal.ansi.yellow": "#f5c211",
-            "terminal.ansi.bright_yellow": "#f8e45c",
-            "terminal.ansi.dim_yellow": "#f5c211",
-            "terminal.ansi.blue": "#1e78e4",
-            "terminal.ansi.bright_blue": "#51a1ff",
-            "terminal.ansi.dim_blue": "#1e78e4",
-            "terminal.ansi.magenta": "#a74aa8",
-            "terminal.ansi.bright_magenta": "#d670e8",
-            "terminal.ansi.dim_magenta": "#a74aa8",
-            "terminal.ansi.cyan": "#0ab9dc",
-            "terminal.ansi.bright_cyan": "#4fd2fd",
-            "terminal.ansi.dim_cyan": "#0ab9dc",
-            "terminal.ansi.white": "#c0bfbf",
-            "terminal.ansi.bright_white": "#f6f5f4",
-            "terminal.ansi.dim_white": "#c0bfbf",
-            "link_text.hover": "#64a0ea",
-            "conflict": "#c061cb",
-            "conflict.border": "#813d9c",
-            "conflict.background": "#303030",
-            "created": "#57e389",
-            "created.border": "#2ec27e",
-            "created.background": "#303030",
-            "deleted": "#ed333b",
-            "deleted.border": "#c01c28",
-            "deleted.background": "#303030",
-            "error": "#ed333b",
-            "error.border": "#c01c28",
-            "error.background": "#303030",
-            "hidden": "#808080",
-            "hidden.border": "#808080",
-            "hidden.background": "#303030",
-            "hint": "#808080",
-            "hint.border": "#808080",
-            "hint.background": "#303030",
-            "ignored": "#808080",
-            "ignored.border": "#808080",
-            "ignored.background": "#303030",
-            "info": "#c7c7c7",
-            "info.border": "#808080",
-            "info.background": "#303030",
-            "modified": "#62a0ea",
-            "modified.border": "#1c71d8",
-            "modified.background": "#303030",
-            "predictive": "#808080",
-            "predictive.border": "#808080",
-            "predictive.background": "#303030",
-            "renamed": "#1c71d8",
-            "renamed.border": "#1c71d8",
-            "renamed.background": "#303030",
-            "success": "#57e389",
-            "success.border": "#2ec27e",
-            "success.background": "#303030",
-            "unreachable": "#ed333b",
-            "unreachable.border": "#c01c28",
-            "unreachable.background": "#303030",
-            "warning": "#f8e45c",
-            "warning.border": "#f8e45c",
-            "warning.background": "#303030",
-            "players": [
-              {
-                "cursor": "#f5e0dc",
-                "selection": "#585b7066",
-                "background": "#f5e0dc"
-              },
-              {
-                "cursor": "#ccc2f5",
-                "selection": "#ccc2f566",
-                "background": "#ccc2f5"
-              },
-              {
-                "cursor": "#bddbd2",
-                "selection": "#bddbd266",
-                "background": "#bddbd2"
-              },
-              {
-                "cursor": "#dcb8d5",
-                "selection": "#dcb8d566",
-                "background": "#dcb8d5"
-              },
-              {
-                "cursor": "#b6dae7",
-                "selection": "#b6dae766",
-                "background": "#b6dae7"
-              },
-              {
-                "cursor": "#dfc8c8",
-                "selection": "#dfc8c866",
-                "background": "#dfc8c8"
-              },
-              {
-                "cursor": "#dfdad8",
-                "selection": "#dfdad866",
-                "background": "#dfdad8"
-              },
-              {
-                "cursor": "#b2c8f6",
-                "selection": "#b2c8f666",
-                "background": "#b2c8f6"
-              }
-            ],
-            "syntax": {
-              "attribute": {
-                "color": "#f9e2af",
-                "font_style": null,
-                "font_weight": null
-              },
-              "boolean": {
-                "color": "#fab387",
-                "font_style": null,
-                "font_weight": null
-              },
-              "comment": {
-                "color": "#7f849c",
-                "font_style": "italic",
-                "font_weight": null
-              },
-              "comment.doc": {
-                "color": "#7f849c",
-                "font_style": "italic",
-                "font_weight": null
-              },
-              "constant": {
-                "color": "#fab387",
-                "font_style": null,
-                "font_weight": null
-              },
-              "constructor": {
-                "color": "#89b4fa",
-                "font_style": null,
-                "font_weight": null
-              },
-              "embedded": {
-                "color": "#eba0ac",
-                "font_style": null,
-                "font_weight": null
-              },
-              "emphasis": {
-                "color": "#f38ba8",
-                "font_style": "italic",
-                "font_weight": null
-              },
-              "emphasis.strong": {
-                "color": "#f38ba8",
-                "font_style": null,
-                "font_weight": 700
-              },
-              "enum": {
-                "color": "#94e2d5",
-                "font_style": null,
-                "font_weight": 700
-              },
-              "function": {
-                "color": "#89b4fa",
-                "font_style": "italic",
-                "font_weight": null
-              },
-              "hint": {
-                "color": "#94e2d5",
-                "font_style": "italic",
-                "font_weight": null
-              },
-              "keyword": {
-                "color": "#cba6f7",
-                "font_style": null,
-                "font_weight": null
-              },
-              "link_text": {
-                "color": "#89b4fa",
-                "font_style": null,
-                "font_weight": null
-              },
-              "link_uri": {
-                "color": "#89b4fa",
-                "font_style": null,
-                "font_weight": null
-              },
-              "number": {
-                "color": "#fab387",
-                "font_style": null,
-                "font_weight": null
-              },
-              "operator": {
-                "color": "#89dceb",
-                "font_style": null,
-                "font_weight": null
-              },
-              "predictive": {
-                "color": "#585b70",
-                "font_style": null,
-                "font_weight": null
-              },
-              "predoc": {
-                "color": "#f38ba8",
-                "font_style": null,
-                "font_weight": null
-              },
-              "primary": {
-                "color": "#eba0ac",
-                "font_style": null,
-                "font_weight": null
-              },
-              "property": {
-                "color": "#89b4fa",
-                "font_style": null,
-                "font_weight": null
-              },
-              "punctuation": {
-                "color": "#94e2d5",
-                "font_style": null,
-                "font_weight": null
-              },
-              "punctuation.bracket": {
-                "color": "#94e2d5",
-                "font_style": null,
-                "font_weight": null
-              },
-              "punctuation.delimiter": {
-                "color": "#9399b2",
-                "font_style": null,
-                "font_weight": null
-              },
-              "punctuation.list_marker": {
-                "color": "#94e2d5",
-                "font_style": null,
-                "font_weight": null
-              },
-              "punctuation.special": {
-                "color": "#94e2d5",
-                "font_style": null,
-                "font_weight": null
-              },
-              "punctuation.special.symbol": {
-                "color": "#f38ba8",
-                "font_style": null,
-                "font_weight": null
-              },
-              "string": {
-                "color": "#a6e3a1",
-                "font_style": null,
-                "font_weight": null
-              },
-              "string.escape": {
-                "color": "#f5c2e7",
-                "font_style": null,
-                "font_weight": null
-              },
-              "string.regex": {
-                "color": "#f5c2e7",
-                "font_style": null,
-                "font_weight": null
-              },
-              "string.special": {
-                "color": "#f5c2e7",
-                "font_style": null,
-                "font_weight": null
-              },
-              "string.special.symbol": {
-                "color": "#f2cdcd",
-                "font_style": null,
-                "font_weight": null
-              },
-              "tag": {
-                "color": "#89b4fa",
-                "font_style": null,
-                "font_weight": null
-              },
-              "text.literal": {
-                "color": "#a6e3a1",
-                "font_style": null,
-                "font_weight": null
-              },
-              "title": {
-                "color": "#cdd6f4",
-                "font_style": null,
-                "font_weight": 800
-              },
-              "type": {
-                "color": "#f9e2af",
-                "font_style": null,
-                "font_weight": null
-              },
-              "type.interface": {
-                "color": "#f9e2af",
-                "font_style": null,
-                "font_weight": null
-              },
-              "type.super": {
-                "color": "#f9e2af",
-                "font_style": null,
-                "font_weight": null
-              },
-              "variable": {
-                "color": "#cdd6f4",
-                "font_style": null,
-                "font_weight": null
-              },
-              "variable.member": {
-                "color": "#cdd6f4",
-                "font_style": null,
-                "font_weight": null
-              },
-              "variable.parameter": {
-                "color": "#fab387",
-                "font_style": "italic",
-                "font_weight": null
-              },
-              "variable.special": {
-                "color": "#dcb8d5",
-                "font_style": "italic",
-                "font_weight": null
-              },
-              "variant": {
-                "color": "#f38ba8",
-                "font_style": null,
-                "font_weight": null
-              }
-            }
-          }
-        },
-        {
-          "name": "Adwaita Pastel Light",
+          "name": "Catppuccin Latte",
           "appearance": "light",
           "style": {
-            "border": "#e1e1e1",
-            "border.variant": "#e1e1e1",
-            "border.focused": "#99c1f1",
-            "border.selected": "#99c1f1",
-            "border.transparent": "#00000000",
-            "border.disabled": "#fafafa",
-            "elevated_surface.background": "#fafafa",
-            "surface.background": "#fafafa",
-            "background": "#ffffff",
-            "element.background": "#fafafa",
-            "element.hover": "#ebebeb",
-            "element.active": "#ebebeb",
-            "element.selected": "#ebebeb",
-            "element.disabled": "#fafafa",
-            "drop_target.background": "#fafafa80",
-            "ghost_element.background": "#00000000",
-            "ghost_element.hover": "#ebebeb",
-            "ghost_element.active": "#ebebeb",
-            "ghost_element.selected": "#ebebeb",
-            "ghost_element.disabled": "#fafafa",
-            "text": "#2f2f2f",
-            "text.muted": "#5f5f5f",
-            "text.placeholder": "#808080",
-            "text.disabled": "#808080",
-            "text.accent": "#808080",
-            "icon": "#2f2f2f",
-            "icon.muted": "#5f5f5f",
-            "icon.disabled": "#808080",
-            "icon.placeholder": "#808080",
-            "icon.accent": "#808080",
-            "status_bar.background": "#ebebeb",
-            "title_bar.background": "#ffffff",
-            "title_bar.inactive_background": "#fafafa",
-            "toolbar.background": "#ffffff",
-            "tab_bar.background": "#ffffff",
-            "tab.inactive_background": "#ffffff",
-            "tab.active_background": "#ebebeb",
-            "search.match_background": "#99c1f166",
-            "panel.background": "#fafafa",
-            "panel.focused_border": null,
-            "pane.focused_border": null,
-            "pane_group.border": "#cfcfcf",
-            "scrollbar.thumb.background": "#2f2f2f30",
-            "scrollbar.thumb.hover_background": "#9f9f9f",
-            "scrollbar.thumb.border": "#ffffff",
-            "scrollbar.track.background": "#00000000",
-            "scrollbar.track.border": "#ebebeb",
-            "editor.foreground": "#2f2f2f",
-            "editor.background": "#ffffff",
-            "editor.gutter.background": "#ffffff",
-            "editor.subheader.background": "#ffffff",
-            "editor.active_line.background": "#ebebeb",
-            "editor.highlighted_line.background": "#ebebeb",
-            "editor.line_number": "#808080",
-            "editor.active_line_number": "#5f5f5f",
-            "editor.invisible": "#808080",
-            "editor.wrap_guide": "#ebebeb",
-            "editor.active_wrap_guide": "#ebebeb",
-            "editor.document_highlight.read_background": "#3584e41a",
-            "editor.document_highlight.write_background": "#ebebeb66",
-            "terminal.background": "#ffffff",
-            "terminal.foreground": "#000000",
-            "terminal.bright_foreground": "#000000",
-            "terminal.dim_foreground": "#000000",
-            "terminal.ansi.black": "#241f31",
-            "terminal.ansi.bright_black": "#5e5c64",
-            "terminal.ansi.dim_black": "#241f31",
-            "terminal.ansi.red": "#c01c28",
-            "terminal.ansi.bright_red": "#ed333b",
-            "terminal.ansi.dim_red": "#c01c28",
-            "terminal.ansi.green": "#2ec27e",
-            "terminal.ansi.bright_green": "#57e389",
-            "terminal.ansi.dim_green": "#2ec27e",
-            "terminal.ansi.yellow": "#f5c211",
-            "terminal.ansi.bright_yellow": "#f8e45c",
-            "terminal.ansi.dim_yellow": "#f5c211",
-            "terminal.ansi.blue": "#1e78e4",
-            "terminal.ansi.bright_blue": "#51a1ff",
-            "terminal.ansi.dim_blue": "#1e78e4",
-            "terminal.ansi.magenta": "#a74aa8",
-            "terminal.ansi.bright_magenta": "#d670e8",
-            "terminal.ansi.dim_magenta": "#a74aa8",
-            "terminal.ansi.cyan": "#0ab9dc",
-            "terminal.ansi.bright_cyan": "#4fd2fd",
-            "terminal.ansi.dim_cyan": "#0ab9dc",
-            "terminal.ansi.white": "#c0bfbf",
-            "terminal.ansi.bright_white": "#f6f5f4",
-            "terminal.ansi.dim_white": "#c0bfbf",
-            "link_text.hover": "#1c71d8",
-            "conflict": "#813d9c",
-            "conflict.border": "#c061cb",
-            "conflict.background": "#ffffff",
-            "created": "#2ec27e",
-            "created.border": "#57e389",
-            "created.background": "#ffffff",
-            "deleted": "#c01c28",
-            "deleted.border": "#ed333b",
-            "deleted.background": "#ffffff",
-            "error": "#c01c28",
-            "error.border": "#ed333b",
-            "error.background": "#ffffff",
-            "hidden": "#808080",
-            "hidden.border": "#808080",
-            "hidden.background": "#ffffff",
-            "hint": "#808080",
-            "hint.border": "#808080",
-            "hint.background": "#ffffff",
-            "ignored": "#808080",
-            "ignored.border": "#808080",
-            "ignored.background": "#ffffff",
-            "info": "#5f5f5f",
-            "info.border": "#808080",
-            "info.background": "#ffffff",
-            "modified": "#1c71d8",
-            "modified.border": "#62a0ea",
-            "modified.background": "#ffffff",
-            "predictive": "#808080",
-            "predictive.border": "#808080",
-            "predictive.background": "#ffffff",
-            "renamed": "#1c71d8",
-            "renamed.border": "#62a0ea",
-            "renamed.background": "#ffffff",
-            "success": "#2ec27e",
-            "success.border": "#57e389",
-            "success.background": "#ffffff",
-            "unreachable": "#c01c28",
-            "unreachable.border": "#ed333b",
-            "unreachable.background": "#ffffff",
-            "warning": "#f5c211",
-            "warning.border": "#f8e45c",
-            "warning.background": "#ffffff",
+            "border": "#ccd0da",
+            "border.variant": "#9658eb",
+            "border.focused": "#7287fd",
+            "border.selected": "#8839ef",
+            "border.transparent": "#40a02b",
+            "border.disabled": "#acb0be",
+            "elevated_surface.background": "#e6e9ef",
+            "surface.background": "#eff1f5",
+            "background": "#eff1f5",
+            "element.background": "#dce0e8",
+            "element.hover": "#9ca0b04d",
+            "element.active": "#8839ef33",
+            "element.selected": "#ccd0da99",
+            "element.disabled": "#9ca0b0",
+            "drop_target.background": "#8839ef66",
+            "ghost_element.background": null,
+            "ghost_element.hover": "#acb0be4d",
+            "ghost_element.active": "#acb0be80",
+            "ghost_element.selected": "#9ca0b059",
+            "ghost_element.disabled": "#9ca0b0",
+            "text": "#4c4f69",
+            "text.muted": "#5c5f77",
+            "text.placeholder": "#acb0be",
+            "text.disabled": "#9ca0b0",
+            "text.accent": "#8839ef",
+            "icon": "#4c4f69",
+            "icon.muted": "#8c8fa1",
+            "icon.disabled": "#9ca0b0",
+            "icon.placeholder": "#acb0be",
+            "icon.accent": "#8839ef",
+            "status_bar.background": "#dce0e8",
+            "title_bar.background": "#dce0e8",
+            "title_bar.inactive_background": "#dce0e8d9",
+            "toolbar.background": "#eff1f5",
+            "tab_bar.background": "#dce0e8",
+            "tab.inactive_background": "#e6e9ef",
+            "tab.active_background": "#eff1f5",
+            "search.match_background": "#17929933",
+            "panel.background": "#e6e9ef",
+            "panel.focused_border": "#4c4f69",
+            "pane.focused_border": "#4c4f69",
+            "scrollbar.thumb.background": "#8839ef33",
+            "scrollbar.thumb.hover_background": "#9ca0b0",
+            "scrollbar.thumb.border": "#acb0be80",
+            "scrollbar.track.background": "#eff1f5",
+            "scrollbar.track.border": "#4c4f6912",
+            "editor.foreground": "#4c4f69",
+            "editor.background": "#eff1f5",
+            "editor.gutter.background": "#eff1f5",
+            "editor.subheader.background": "#e6e9ef",
+            "editor.active_line.background": "#4c4f690d",
+            "editor.highlighted_line.background": null,
+            "editor.line_number": "#8c8fa1",
+            "editor.active_line_number": "#8839ef",
+            "editor.invisible": "#7c7f9366",
+            "editor.wrap_guide": "#acb0be",
+            "editor.active_wrap_guide": "#acb0be",
+            "editor.document_highlight.read_background": "#6c6f8529",
+            "editor.document_highlight.write_background": "#6c6f8529",
+            "terminal.background": "#eff1f5",
+            "terminal.foreground": "#4c4f69",
+            "terminal.dim_foreground": "#8c8fa1",
+            "terminal.bright_foreground": "#4c4f69",
+            "terminal.ansi.black": "#bcc0cc",
+            "terminal.ansi.red": "#d20f39",
+            "terminal.ansi.green": "#40a02b",
+            "terminal.ansi.yellow": "#df8e1d",
+            "terminal.ansi.blue": "#1e66f5",
+            "terminal.ansi.magenta": "#ea76cb",
+            "terminal.ansi.cyan": "#179299",
+            "terminal.ansi.white": "#4c4f69",
+            "terminal.ansi.bright_black": "#acb0be",
+            "terminal.ansi.bright_red": "#d20f39",
+            "terminal.ansi.bright_green": "#40a02b",
+            "terminal.ansi.bright_yellow": "#df8e1d",
+            "terminal.ansi.bright_blue": "#1e66f5",
+            "terminal.ansi.bright_magenta": "#ea76cb",
+            "terminal.ansi.bright_cyan": "#179299",
+            "terminal.ansi.bright_white": "#6c6f85",
+            "terminal.ansi.dim_black": "#bcc0cc",
+            "terminal.ansi.dim_red": "#d20f39",
+            "terminal.ansi.dim_green": "#40a02b",
+            "terminal.ansi.dim_yellow": "#df8e1d",
+            "terminal.ansi.dim_blue": "#1e66f5",
+            "terminal.ansi.dim_magenta": "#ea76cb",
+            "terminal.ansi.dim_cyan": "#179299",
+            "terminal.ansi.dim_white": "#5c5f77",
+            "link_text.hover": "#04a5e5",
+            "conflict": "#8839ef",
+            "conflict.border": "#8839ef",
+            "conflict.background": "#e6e9ef",
+            "created": "#40a02b",
+            "created.border": "#40a02b",
+            "created.background": "#e6e9ef",
+            "deleted": "#d20f39",
+            "deleted.border": "#d20f39",
+            "deleted.background": "#e6e9ef",
+            "error": "#d20f39",
+            "error.border": "#d20f39",
+            "error.background": "#e6e9ef",
+            "hidden": "#9ca0b0",
+            "hidden.border": "#9ca0b0",
+            "hidden.background": "#e6e9ef",
+            "hint": "#acb0be",
+            "hint.border": "#acb0be",
+            "hint.background": "#e6e9ef",
+            "ignored": "#9ca0b0",
+            "ignored.border": "#9ca0b0",
+            "ignored.background": "#e6e9ef",
+            "info": "#179299",
+            "info.border": "#179299",
+            "info.background": "#8839ef66",
+            "modified": "#df8e1d",
+            "modified.border": "#df8e1d",
+            "modified.background": "#e6e9ef",
+            "predictive": "#acb0be",
+            "predictive.border": "#acb0be",
+            "predictive.background": "#e6e9ef",
+            "renamed": "#209fb5",
+            "renamed.border": "#209fb5",
+            "renamed.background": "#e6e9ef",
+            "success": "#40a02b",
+            "success.border": "#40a02b",
+            "success.background": "#e6e9ef",
+            "unreachable": "#d20f39",
+            "unreachable.border": "#d20f39",
+            "unreachable.background": "#e6e9ef",
+            "warning": "#fe640b",
+            "warning.border": "#fe640b",
+            "warning.background": "#e6e9ef",
             "players": [
               {
                 "cursor": "#dc8a78",
-                "selection": "#acb0be66",
+                "selection": "#acb0be80",
                 "background": "#dc8a78"
               },
               {
-                "cursor": "#64469f",
-                "selection": "#64469f66",
-                "background": "#64469f"
-              },
-              {
-                "cursor": "#486f50",
-                "selection": "#486f5066",
-                "background": "#486f50"
+                "cursor": "#3b6f87",
+                "selection": "#3b6f8733",
+                "background": "#3b6f87"
               },
               {
                 "cursor": "#823556",
-                "selection": "#82355666",
+                "selection": "#82355633",
                 "background": "#823556"
               },
               {
                 "cursor": "#37697c",
-                "selection": "#37697c66",
+                "selection": "#37697c33",
                 "background": "#37697c"
               },
               {
                 "cursor": "#945743",
-                "selection": "#94574366",
+                "selection": "#94574333",
                 "background": "#945743"
               },
               {
                 "cursor": "#87684b",
-                "selection": "#87684b66",
+                "selection": "#87684b33",
                 "background": "#87684b"
               },
               {
                 "cursor": "#3a58a1",
-                "selection": "#3a58a166",
+                "selection": "#3a58a133",
                 "background": "#3a58a1"
+              },
+              {
+                "cursor": "#486f50",
+                "selection": "#486f5033",
+                "background": "#486f50"
               }
             ],
             "syntax": {
@@ -1512,49 +407,6698 @@
               }
             }
           }
+        },
+        {
+          "name": "Catppuccin Frappé",
+          "appearance": "dark",
+          "style": {
+            "border": "#414559",
+            "border.variant": "#af8cca",
+            "border.focused": "#babbf1",
+            "border.selected": "#ca9ee6",
+            "border.transparent": "#a6d189",
+            "border.disabled": "#626880",
+            "elevated_surface.background": "#292c3c",
+            "surface.background": "#303446",
+            "background": "#303446",
+            "element.background": "#232634",
+            "element.hover": "#7379944d",
+            "element.active": "#ca9ee633",
+            "element.selected": "#41455999",
+            "element.disabled": "#737994",
+            "drop_target.background": "#ca9ee666",
+            "ghost_element.background": null,
+            "ghost_element.hover": "#6268804d",
+            "ghost_element.active": "#62688080",
+            "ghost_element.selected": "#73799459",
+            "ghost_element.disabled": "#737994",
+            "text": "#c6d0f5",
+            "text.muted": "#b5bfe2",
+            "text.placeholder": "#626880",
+            "text.disabled": "#737994",
+            "text.accent": "#ca9ee6",
+            "icon": "#c6d0f5",
+            "icon.muted": "#838ba7",
+            "icon.disabled": "#737994",
+            "icon.placeholder": "#626880",
+            "icon.accent": "#ca9ee6",
+            "status_bar.background": "#232634",
+            "title_bar.background": "#232634",
+            "title_bar.inactive_background": "#232634d9",
+            "toolbar.background": "#303446",
+            "tab_bar.background": "#232634",
+            "tab.inactive_background": "#292c3c",
+            "tab.active_background": "#303446",
+            "search.match_background": "#81c8be33",
+            "panel.background": "#292c3c",
+            "panel.focused_border": "#c6d0f5",
+            "pane.focused_border": "#c6d0f5",
+            "scrollbar.thumb.background": "#ca9ee633",
+            "scrollbar.thumb.hover_background": "#737994",
+            "scrollbar.thumb.border": "#62688080",
+            "scrollbar.track.background": "#303446",
+            "scrollbar.track.border": "#c6d0f512",
+            "editor.foreground": "#c6d0f5",
+            "editor.background": "#303446",
+            "editor.gutter.background": "#303446",
+            "editor.subheader.background": "#292c3c",
+            "editor.active_line.background": "#c6d0f50d",
+            "editor.highlighted_line.background": null,
+            "editor.line_number": "#838ba7",
+            "editor.active_line_number": "#ca9ee6",
+            "editor.invisible": "#949cbb66",
+            "editor.wrap_guide": "#626880",
+            "editor.active_wrap_guide": "#626880",
+            "editor.document_highlight.read_background": "#a5adce29",
+            "editor.document_highlight.write_background": "#a5adce29",
+            "terminal.background": "#303446",
+            "terminal.foreground": "#c6d0f5",
+            "terminal.dim_foreground": "#838ba7",
+            "terminal.bright_foreground": "#c6d0f5",
+            "terminal.ansi.black": "#51576d",
+            "terminal.ansi.red": "#e78284",
+            "terminal.ansi.green": "#a6d189",
+            "terminal.ansi.yellow": "#e5c890",
+            "terminal.ansi.blue": "#8caaee",
+            "terminal.ansi.magenta": "#f4b8e4",
+            "terminal.ansi.cyan": "#81c8be",
+            "terminal.ansi.white": "#c6d0f5",
+            "terminal.ansi.bright_black": "#626880",
+            "terminal.ansi.bright_red": "#e78284",
+            "terminal.ansi.bright_green": "#a6d189",
+            "terminal.ansi.bright_yellow": "#e5c890",
+            "terminal.ansi.bright_blue": "#8caaee",
+            "terminal.ansi.bright_magenta": "#f4b8e4",
+            "terminal.ansi.bright_cyan": "#81c8be",
+            "terminal.ansi.bright_white": "#a5adce",
+            "terminal.ansi.dim_black": "#51576d",
+            "terminal.ansi.dim_red": "#e78284",
+            "terminal.ansi.dim_green": "#a6d189",
+            "terminal.ansi.dim_yellow": "#e5c890",
+            "terminal.ansi.dim_blue": "#8caaee",
+            "terminal.ansi.dim_magenta": "#f4b8e4",
+            "terminal.ansi.dim_cyan": "#81c8be",
+            "terminal.ansi.dim_white": "#b5bfe2",
+            "link_text.hover": "#99d1db",
+            "conflict": "#ca9ee6",
+            "conflict.border": "#ca9ee6",
+            "conflict.background": "#292c3c",
+            "created": "#a6d189",
+            "created.border": "#a6d189",
+            "created.background": "#292c3c",
+            "deleted": "#e78284",
+            "deleted.border": "#e78284",
+            "deleted.background": "#292c3c",
+            "error": "#e78284",
+            "error.border": "#e78284",
+            "error.background": "#292c3c",
+            "hidden": "#737994",
+            "hidden.border": "#737994",
+            "hidden.background": "#292c3c",
+            "hint": "#626880",
+            "hint.border": "#626880",
+            "hint.background": "#292c3c",
+            "ignored": "#737994",
+            "ignored.border": "#737994",
+            "ignored.background": "#292c3c",
+            "info": "#81c8be",
+            "info.border": "#81c8be",
+            "info.background": "#ca9ee666",
+            "modified": "#e5c890",
+            "modified.border": "#e5c890",
+            "modified.background": "#292c3c",
+            "predictive": "#626880",
+            "predictive.border": "#626880",
+            "predictive.background": "#292c3c",
+            "renamed": "#85c1dc",
+            "renamed.border": "#85c1dc",
+            "renamed.background": "#292c3c",
+            "success": "#a6d189",
+            "success.border": "#a6d189",
+            "success.background": "#292c3c",
+            "unreachable": "#e78284",
+            "unreachable.border": "#e78284",
+            "unreachable.background": "#292c3c",
+            "warning": "#ef9f76",
+            "warning.border": "#ef9f76",
+            "warning.background": "#292c3c",
+            "players": [
+              {
+                "cursor": "#f2d5cf",
+                "selection": "#62688080",
+                "background": "#f2d5cf"
+              },
+              {
+                "cursor": "#accaeb",
+                "selection": "#accaeb33",
+                "background": "#accaeb"
+              },
+              {
+                "cursor": "#d3b1c8",
+                "selection": "#d3b1c833",
+                "background": "#d3b1c8"
+              },
+              {
+                "cursor": "#abcddf",
+                "selection": "#abcddf33",
+                "background": "#abcddf"
+              },
+              {
+                "cursor": "#d7bdc2",
+                "selection": "#d7bdc233",
+                "background": "#d7bdc2"
+              },
+              {
+                "cursor": "#d3cdcd",
+                "selection": "#d3cdcd33",
+                "background": "#d3cdcd"
+              },
+              {
+                "cursor": "#afc1f2",
+                "selection": "#afc1f233",
+                "background": "#afc1f2"
+              },
+              {
+                "cursor": "#b9d1ca",
+                "selection": "#b9d1ca33",
+                "background": "#b9d1ca"
+              }
+            ],
+            "syntax": {
+              "attribute": {
+                "color": "#e5c890",
+                "font_style": null,
+                "font_weight": null
+              },
+              "boolean": {
+                "color": "#ef9f76",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment": {
+                "color": "#838ba7",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "comment.doc": {
+                "color": "#838ba7",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "constant": {
+                "color": "#ef9f76",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constructor": {
+                "color": "#8caaee",
+                "font_style": null,
+                "font_weight": null
+              },
+              "embedded": {
+                "color": "#ea999c",
+                "font_style": null,
+                "font_weight": null
+              },
+              "emphasis": {
+                "color": "#e78284",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "emphasis.strong": {
+                "color": "#e78284",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "enum": {
+                "color": "#81c8be",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "function": {
+                "color": "#8caaee",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "hint": {
+                "color": "#81c8be",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "keyword": {
+                "color": "#ca9ee6",
+                "font_style": null,
+                "font_weight": null
+              },
+              "link_text": {
+                "color": "#8caaee",
+                "font_style": null,
+                "font_weight": null
+              },
+              "link_uri": {
+                "color": "#8caaee",
+                "font_style": null,
+                "font_weight": null
+              },
+              "number": {
+                "color": "#ef9f76",
+                "font_style": null,
+                "font_weight": null
+              },
+              "operator": {
+                "color": "#99d1db",
+                "font_style": null,
+                "font_weight": null
+              },
+              "predictive": {
+                "color": "#626880",
+                "font_style": null,
+                "font_weight": null
+              },
+              "predoc": {
+                "color": "#e78284",
+                "font_style": null,
+                "font_weight": null
+              },
+              "primary": {
+                "color": "#ea999c",
+                "font_style": null,
+                "font_weight": null
+              },
+              "property": {
+                "color": "#8caaee",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation": {
+                "color": "#81c8be",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.bracket": {
+                "color": "#81c8be",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.delimiter": {
+                "color": "#949cbb",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.list_marker": {
+                "color": "#81c8be",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.special": {
+                "color": "#81c8be",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.special.symbol": {
+                "color": "#e78284",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string": {
+                "color": "#a6d189",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.escape": {
+                "color": "#f4b8e4",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.regex": {
+                "color": "#f4b8e4",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special": {
+                "color": "#f4b8e4",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special.symbol": {
+                "color": "#eebebe",
+                "font_style": null,
+                "font_weight": null
+              },
+              "tag": {
+                "color": "#8caaee",
+                "font_style": null,
+                "font_weight": null
+              },
+              "text.literal": {
+                "color": "#a6d189",
+                "font_style": null,
+                "font_weight": null
+              },
+              "title": {
+                "color": "#c6d0f5",
+                "font_style": null,
+                "font_weight": 800
+              },
+              "type": {
+                "color": "#e5c890",
+                "font_style": null,
+                "font_weight": null
+              },
+              "type.interface": {
+                "color": "#e5c890",
+                "font_style": null,
+                "font_weight": null
+              },
+              "type.super": {
+                "color": "#e5c890",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable": {
+                "color": "#c6d0f5",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable.member": {
+                "color": "#c6d0f5",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable.parameter": {
+                "color": "#ef9f76",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "variable.special": {
+                "color": "#d3b1c8",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "variant": {
+                "color": "#e78284",
+                "font_style": null,
+                "font_weight": null
+              }
+            }
+          }
+        },
+        {
+          "name": "Catppuccin Macchiato",
+          "appearance": "dark",
+          "style": {
+            "border": "#363a4f",
+            "border.variant": "#a98cd5",
+            "border.focused": "#b7bdf8",
+            "border.selected": "#c6a0f6",
+            "border.transparent": "#a6da95",
+            "border.disabled": "#5b6078",
+            "elevated_surface.background": "#1e2030",
+            "surface.background": "#24273a",
+            "background": "#24273a",
+            "element.background": "#181926",
+            "element.hover": "#6e738d4d",
+            "element.active": "#c6a0f633",
+            "element.selected": "#363a4f99",
+            "element.disabled": "#6e738d",
+            "drop_target.background": "#c6a0f666",
+            "ghost_element.background": null,
+            "ghost_element.hover": "#5b60784d",
+            "ghost_element.active": "#5b607880",
+            "ghost_element.selected": "#6e738d59",
+            "ghost_element.disabled": "#6e738d",
+            "text": "#cad3f5",
+            "text.muted": "#b8c0e0",
+            "text.placeholder": "#5b6078",
+            "text.disabled": "#6e738d",
+            "text.accent": "#c6a0f6",
+            "icon": "#cad3f5",
+            "icon.muted": "#8087a2",
+            "icon.disabled": "#6e738d",
+            "icon.placeholder": "#5b6078",
+            "icon.accent": "#c6a0f6",
+            "status_bar.background": "#181926",
+            "title_bar.background": "#181926",
+            "title_bar.inactive_background": "#181926d9",
+            "toolbar.background": "#24273a",
+            "tab_bar.background": "#181926",
+            "tab.inactive_background": "#1e2030",
+            "tab.active_background": "#24273a",
+            "search.match_background": "#8bd5ca33",
+            "panel.background": "#1e2030",
+            "panel.focused_border": "#cad3f5",
+            "pane.focused_border": "#cad3f5",
+            "scrollbar.thumb.background": "#c6a0f633",
+            "scrollbar.thumb.hover_background": "#6e738d",
+            "scrollbar.thumb.border": "#5b607880",
+            "scrollbar.track.background": "#24273a",
+            "scrollbar.track.border": "#cad3f512",
+            "editor.foreground": "#cad3f5",
+            "editor.background": "#24273a",
+            "editor.gutter.background": "#24273a",
+            "editor.subheader.background": "#1e2030",
+            "editor.active_line.background": "#cad3f50d",
+            "editor.highlighted_line.background": null,
+            "editor.line_number": "#8087a2",
+            "editor.active_line_number": "#c6a0f6",
+            "editor.invisible": "#939ab766",
+            "editor.wrap_guide": "#5b6078",
+            "editor.active_wrap_guide": "#5b6078",
+            "editor.document_highlight.read_background": "#a5adcb29",
+            "editor.document_highlight.write_background": "#a5adcb29",
+            "terminal.background": "#24273a",
+            "terminal.foreground": "#cad3f5",
+            "terminal.dim_foreground": "#8087a2",
+            "terminal.bright_foreground": "#cad3f5",
+            "terminal.ansi.black": "#494d64",
+            "terminal.ansi.red": "#ed8796",
+            "terminal.ansi.green": "#a6da95",
+            "terminal.ansi.yellow": "#eed49f",
+            "terminal.ansi.blue": "#8aadf4",
+            "terminal.ansi.magenta": "#f5bde6",
+            "terminal.ansi.cyan": "#8bd5ca",
+            "terminal.ansi.white": "#cad3f5",
+            "terminal.ansi.bright_black": "#5b6078",
+            "terminal.ansi.bright_red": "#ed8796",
+            "terminal.ansi.bright_green": "#a6da95",
+            "terminal.ansi.bright_yellow": "#eed49f",
+            "terminal.ansi.bright_blue": "#8aadf4",
+            "terminal.ansi.bright_magenta": "#f5bde6",
+            "terminal.ansi.bright_cyan": "#8bd5ca",
+            "terminal.ansi.bright_white": "#a5adcb",
+            "terminal.ansi.dim_black": "#494d64",
+            "terminal.ansi.dim_red": "#ed8796",
+            "terminal.ansi.dim_green": "#a6da95",
+            "terminal.ansi.dim_yellow": "#eed49f",
+            "terminal.ansi.dim_blue": "#8aadf4",
+            "terminal.ansi.dim_magenta": "#f5bde6",
+            "terminal.ansi.dim_cyan": "#8bd5ca",
+            "terminal.ansi.dim_white": "#b8c0e0",
+            "link_text.hover": "#91d7e3",
+            "conflict": "#c6a0f6",
+            "conflict.border": "#c6a0f6",
+            "conflict.background": "#1e2030",
+            "created": "#a6da95",
+            "created.border": "#a6da95",
+            "created.background": "#1e2030",
+            "deleted": "#ed8796",
+            "deleted.border": "#ed8796",
+            "deleted.background": "#1e2030",
+            "error": "#ed8796",
+            "error.border": "#ed8796",
+            "error.background": "#1e2030",
+            "hidden": "#6e738d",
+            "hidden.border": "#6e738d",
+            "hidden.background": "#1e2030",
+            "hint": "#5b6078",
+            "hint.border": "#5b6078",
+            "hint.background": "#1e2030",
+            "ignored": "#6e738d",
+            "ignored.border": "#6e738d",
+            "ignored.background": "#1e2030",
+            "info": "#8bd5ca",
+            "info.border": "#8bd5ca",
+            "info.background": "#c6a0f666",
+            "modified": "#eed49f",
+            "modified.border": "#eed49f",
+            "modified.background": "#1e2030",
+            "predictive": "#5b6078",
+            "predictive.border": "#5b6078",
+            "predictive.background": "#1e2030",
+            "renamed": "#7dc4e4",
+            "renamed.border": "#7dc4e4",
+            "renamed.background": "#1e2030",
+            "success": "#a6da95",
+            "success.border": "#a6da95",
+            "success.background": "#1e2030",
+            "unreachable": "#ed8796",
+            "unreachable.border": "#ed8796",
+            "unreachable.background": "#1e2030",
+            "warning": "#f5a97f",
+            "warning.border": "#f5a97f",
+            "warning.background": "#1e2030",
+            "players": [
+              {
+                "cursor": "#f4dbd6",
+                "selection": "#5b607880",
+                "background": "#f4dbd6"
+              },
+              {
+                "cursor": "#abcdee",
+                "selection": "#abcdee33",
+                "background": "#abcdee"
+              },
+              {
+                "cursor": "#d8b5cf",
+                "selection": "#d8b5cf33",
+                "background": "#d8b5cf"
+              },
+              {
+                "cursor": "#b1d4e4",
+                "selection": "#b1d4e433",
+                "background": "#b1d4e4"
+              },
+              {
+                "cursor": "#dbc3c6",
+                "selection": "#dbc3c633",
+                "background": "#dbc3c6"
+              },
+              {
+                "cursor": "#d8d4d3",
+                "selection": "#d8d4d333",
+                "background": "#d8d4d3"
+              },
+              {
+                "cursor": "#b0c4f5",
+                "selection": "#b0c4f533",
+                "background": "#b0c4f5"
+              },
+              {
+                "cursor": "#bbd6cf",
+                "selection": "#bbd6cf33",
+                "background": "#bbd6cf"
+              }
+            ],
+            "syntax": {
+              "attribute": {
+                "color": "#eed49f",
+                "font_style": null,
+                "font_weight": null
+              },
+              "boolean": {
+                "color": "#f5a97f",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment": {
+                "color": "#8087a2",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "comment.doc": {
+                "color": "#8087a2",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "constant": {
+                "color": "#f5a97f",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constructor": {
+                "color": "#8aadf4",
+                "font_style": null,
+                "font_weight": null
+              },
+              "embedded": {
+                "color": "#ee99a0",
+                "font_style": null,
+                "font_weight": null
+              },
+              "emphasis": {
+                "color": "#ed8796",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "emphasis.strong": {
+                "color": "#ed8796",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "enum": {
+                "color": "#8bd5ca",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "function": {
+                "color": "#8aadf4",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "hint": {
+                "color": "#8bd5ca",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "keyword": {
+                "color": "#c6a0f6",
+                "font_style": null,
+                "font_weight": null
+              },
+              "link_text": {
+                "color": "#8aadf4",
+                "font_style": null,
+                "font_weight": null
+              },
+              "link_uri": {
+                "color": "#8aadf4",
+                "font_style": null,
+                "font_weight": null
+              },
+              "number": {
+                "color": "#f5a97f",
+                "font_style": null,
+                "font_weight": null
+              },
+              "operator": {
+                "color": "#91d7e3",
+                "font_style": null,
+                "font_weight": null
+              },
+              "predictive": {
+                "color": "#5b6078",
+                "font_style": null,
+                "font_weight": null
+              },
+              "predoc": {
+                "color": "#ed8796",
+                "font_style": null,
+                "font_weight": null
+              },
+              "primary": {
+                "color": "#ee99a0",
+                "font_style": null,
+                "font_weight": null
+              },
+              "property": {
+                "color": "#8aadf4",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation": {
+                "color": "#8bd5ca",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.bracket": {
+                "color": "#8bd5ca",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.delimiter": {
+                "color": "#939ab7",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.list_marker": {
+                "color": "#8bd5ca",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.special": {
+                "color": "#8bd5ca",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.special.symbol": {
+                "color": "#ed8796",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string": {
+                "color": "#a6da95",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.escape": {
+                "color": "#f5bde6",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.regex": {
+                "color": "#f5bde6",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special": {
+                "color": "#f5bde6",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special.symbol": {
+                "color": "#f0c6c6",
+                "font_style": null,
+                "font_weight": null
+              },
+              "tag": {
+                "color": "#8aadf4",
+                "font_style": null,
+                "font_weight": null
+              },
+              "text.literal": {
+                "color": "#a6da95",
+                "font_style": null,
+                "font_weight": null
+              },
+              "title": {
+                "color": "#cad3f5",
+                "font_style": null,
+                "font_weight": 800
+              },
+              "type": {
+                "color": "#eed49f",
+                "font_style": null,
+                "font_weight": null
+              },
+              "type.interface": {
+                "color": "#eed49f",
+                "font_style": null,
+                "font_weight": null
+              },
+              "type.super": {
+                "color": "#eed49f",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable": {
+                "color": "#cad3f5",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable.member": {
+                "color": "#cad3f5",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable.parameter": {
+                "color": "#f5a97f",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "variable.special": {
+                "color": "#d8b5cf",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "variant": {
+                "color": "#ed8796",
+                "font_style": null,
+                "font_weight": null
+              }
+            }
+          }
+        },
+        {
+          "name": "Catppuccin Mocha",
+          "appearance": "dark",
+          "style": {
+            "border": "#313244",
+            "border.variant": "#ac8fd4",
+            "border.focused": "#b4befe",
+            "border.selected": "#cba6f7",
+            "border.transparent": "#a6e3a1",
+            "border.disabled": "#585b70",
+            "elevated_surface.background": "#181825",
+            "surface.background": "#1e1e2e",
+            "background": "#1e1e2e",
+            "element.background": "#11111b",
+            "element.hover": "#6c70864d",
+            "element.active": "#cba6f733",
+            "element.selected": "#31324499",
+            "element.disabled": "#6c7086",
+            "drop_target.background": "#cba6f766",
+            "ghost_element.background": null,
+            "ghost_element.hover": "#585b704d",
+            "ghost_element.active": "#585b7080",
+            "ghost_element.selected": "#6c708659",
+            "ghost_element.disabled": "#6c7086",
+            "text": "#cdd6f4",
+            "text.muted": "#bac2de",
+            "text.placeholder": "#585b70",
+            "text.disabled": "#6c7086",
+            "text.accent": "#cba6f7",
+            "icon": "#cdd6f4",
+            "icon.muted": "#7f849c",
+            "icon.disabled": "#6c7086",
+            "icon.placeholder": "#585b70",
+            "icon.accent": "#cba6f7",
+            "status_bar.background": "#11111b",
+            "title_bar.background": "#11111b",
+            "title_bar.inactive_background": "#11111bd9",
+            "toolbar.background": "#1e1e2e",
+            "tab_bar.background": "#11111b",
+            "tab.inactive_background": "#181825",
+            "tab.active_background": "#1e1e2e",
+            "search.match_background": "#94e2d533",
+            "panel.background": "#181825",
+            "panel.focused_border": "#cdd6f4",
+            "pane.focused_border": "#cdd6f4",
+            "scrollbar.thumb.background": "#cba6f733",
+            "scrollbar.thumb.hover_background": "#6c7086",
+            "scrollbar.thumb.border": "#585b7080",
+            "scrollbar.track.background": "#1e1e2e",
+            "scrollbar.track.border": "#cdd6f412",
+            "editor.foreground": "#cdd6f4",
+            "editor.background": "#1e1e2e",
+            "editor.gutter.background": "#1e1e2e",
+            "editor.subheader.background": "#181825",
+            "editor.active_line.background": "#cdd6f40d",
+            "editor.highlighted_line.background": null,
+            "editor.line_number": "#7f849c",
+            "editor.active_line_number": "#cba6f7",
+            "editor.invisible": "#9399b266",
+            "editor.wrap_guide": "#585b70",
+            "editor.active_wrap_guide": "#585b70",
+            "editor.document_highlight.read_background": "#a6adc829",
+            "editor.document_highlight.write_background": "#a6adc829",
+            "terminal.background": "#1e1e2e",
+            "terminal.foreground": "#cdd6f4",
+            "terminal.dim_foreground": "#7f849c",
+            "terminal.bright_foreground": "#cdd6f4",
+            "terminal.ansi.black": "#45475a",
+            "terminal.ansi.red": "#f38ba8",
+            "terminal.ansi.green": "#a6e3a1",
+            "terminal.ansi.yellow": "#f9e2af",
+            "terminal.ansi.blue": "#89b4fa",
+            "terminal.ansi.magenta": "#f5c2e7",
+            "terminal.ansi.cyan": "#94e2d5",
+            "terminal.ansi.white": "#cdd6f4",
+            "terminal.ansi.bright_black": "#585b70",
+            "terminal.ansi.bright_red": "#f38ba8",
+            "terminal.ansi.bright_green": "#a6e3a1",
+            "terminal.ansi.bright_yellow": "#f9e2af",
+            "terminal.ansi.bright_blue": "#89b4fa",
+            "terminal.ansi.bright_magenta": "#f5c2e7",
+            "terminal.ansi.bright_cyan": "#94e2d5",
+            "terminal.ansi.bright_white": "#a6adc8",
+            "terminal.ansi.dim_black": "#45475a",
+            "terminal.ansi.dim_red": "#f38ba8",
+            "terminal.ansi.dim_green": "#a6e3a1",
+            "terminal.ansi.dim_yellow": "#f9e2af",
+            "terminal.ansi.dim_blue": "#89b4fa",
+            "terminal.ansi.dim_magenta": "#f5c2e7",
+            "terminal.ansi.dim_cyan": "#94e2d5",
+            "terminal.ansi.dim_white": "#bac2de",
+            "link_text.hover": "#89dceb",
+            "conflict": "#cba6f7",
+            "conflict.border": "#cba6f7",
+            "conflict.background": "#181825",
+            "created": "#a6e3a1",
+            "created.border": "#a6e3a1",
+            "created.background": "#181825",
+            "deleted": "#f38ba8",
+            "deleted.border": "#f38ba8",
+            "deleted.background": "#181825",
+            "error": "#f38ba8",
+            "error.border": "#f38ba8",
+            "error.background": "#181825",
+            "hidden": "#6c7086",
+            "hidden.border": "#6c7086",
+            "hidden.background": "#181825",
+            "hint": "#585b70",
+            "hint.border": "#585b70",
+            "hint.background": "#181825",
+            "ignored": "#6c7086",
+            "ignored.border": "#6c7086",
+            "ignored.background": "#181825",
+            "info": "#94e2d5",
+            "info.border": "#94e2d5",
+            "info.background": "#cba6f766",
+            "modified": "#f9e2af",
+            "modified.border": "#f9e2af",
+            "modified.background": "#181825",
+            "predictive": "#585b70",
+            "predictive.border": "#585b70",
+            "predictive.background": "#181825",
+            "renamed": "#74c7ec",
+            "renamed.border": "#74c7ec",
+            "renamed.background": "#181825",
+            "success": "#a6e3a1",
+            "success.border": "#a6e3a1",
+            "success.background": "#181825",
+            "unreachable": "#f38ba8",
+            "unreachable.border": "#f38ba8",
+            "unreachable.background": "#181825",
+            "warning": "#fab387",
+            "warning.border": "#fab387",
+            "warning.background": "#181825",
+            "players": [
+              {
+                "cursor": "#f5e0dc",
+                "selection": "#585b7080",
+                "background": "#f5e0dc"
+              },
+              {
+                "cursor": "#a9d0f0",
+                "selection": "#a9d0f033",
+                "background": "#a9d0f0"
+              },
+              {
+                "cursor": "#dcb8d5",
+                "selection": "#dcb8d533",
+                "background": "#dcb8d5"
+              },
+              {
+                "cursor": "#b6dae7",
+                "selection": "#b6dae733",
+                "background": "#b6dae7"
+              },
+              {
+                "cursor": "#dfc8c8",
+                "selection": "#dfc8c833",
+                "background": "#dfc8c8"
+              },
+              {
+                "cursor": "#dfdad8",
+                "selection": "#dfdad833",
+                "background": "#dfdad8"
+              },
+              {
+                "cursor": "#b2c8f6",
+                "selection": "#b2c8f633",
+                "background": "#b2c8f6"
+              },
+              {
+                "cursor": "#bddbd2",
+                "selection": "#bddbd233",
+                "background": "#bddbd2"
+              }
+            ],
+            "syntax": {
+              "attribute": {
+                "color": "#f9e2af",
+                "font_style": null,
+                "font_weight": null
+              },
+              "boolean": {
+                "color": "#fab387",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment": {
+                "color": "#7f849c",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "comment.doc": {
+                "color": "#7f849c",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "constant": {
+                "color": "#fab387",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constructor": {
+                "color": "#89b4fa",
+                "font_style": null,
+                "font_weight": null
+              },
+              "embedded": {
+                "color": "#eba0ac",
+                "font_style": null,
+                "font_weight": null
+              },
+              "emphasis": {
+                "color": "#f38ba8",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "emphasis.strong": {
+                "color": "#f38ba8",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "enum": {
+                "color": "#94e2d5",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "function": {
+                "color": "#89b4fa",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "hint": {
+                "color": "#94e2d5",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "keyword": {
+                "color": "#cba6f7",
+                "font_style": null,
+                "font_weight": null
+              },
+              "link_text": {
+                "color": "#89b4fa",
+                "font_style": null,
+                "font_weight": null
+              },
+              "link_uri": {
+                "color": "#89b4fa",
+                "font_style": null,
+                "font_weight": null
+              },
+              "number": {
+                "color": "#fab387",
+                "font_style": null,
+                "font_weight": null
+              },
+              "operator": {
+                "color": "#89dceb",
+                "font_style": null,
+                "font_weight": null
+              },
+              "predictive": {
+                "color": "#585b70",
+                "font_style": null,
+                "font_weight": null
+              },
+              "predoc": {
+                "color": "#f38ba8",
+                "font_style": null,
+                "font_weight": null
+              },
+              "primary": {
+                "color": "#eba0ac",
+                "font_style": null,
+                "font_weight": null
+              },
+              "property": {
+                "color": "#89b4fa",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation": {
+                "color": "#94e2d5",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.bracket": {
+                "color": "#94e2d5",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.delimiter": {
+                "color": "#9399b2",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.list_marker": {
+                "color": "#94e2d5",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.special": {
+                "color": "#94e2d5",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.special.symbol": {
+                "color": "#f38ba8",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string": {
+                "color": "#a6e3a1",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.escape": {
+                "color": "#f5c2e7",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.regex": {
+                "color": "#f5c2e7",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special": {
+                "color": "#f5c2e7",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special.symbol": {
+                "color": "#f2cdcd",
+                "font_style": null,
+                "font_weight": null
+              },
+              "tag": {
+                "color": "#89b4fa",
+                "font_style": null,
+                "font_weight": null
+              },
+              "text.literal": {
+                "color": "#a6e3a1",
+                "font_style": null,
+                "font_weight": null
+              },
+              "title": {
+                "color": "#cdd6f4",
+                "font_style": null,
+                "font_weight": 800
+              },
+              "type": {
+                "color": "#f9e2af",
+                "font_style": null,
+                "font_weight": null
+              },
+              "type.interface": {
+                "color": "#f9e2af",
+                "font_style": null,
+                "font_weight": null
+              },
+              "type.super": {
+                "color": "#f9e2af",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable": {
+                "color": "#cdd6f4",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable.member": {
+                "color": "#cdd6f4",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable.parameter": {
+                "color": "#fab387",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "variable.special": {
+                "color": "#dcb8d5",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "variant": {
+                "color": "#f38ba8",
+                "font_style": null,
+                "font_weight": null
+              }
+            }
+          }
         }
       ]
     },
     "userId": null,
-    "installCount": 1983
+    "installCount": 127411
   },
   {
-    "id": "alabaster",
-    "name": "Alabaster",
-    "author": "Vitali Tsimoshka (theme originally by Nikita Prokopov)",
-    "updatedDate": 1711982896000,
-    "versionHash": "bd158be",
+    "id": "macos-classic",
+    "name": "macOS Classic",
+    "author": "Jason Lee",
+    "updatedDate": 1729002665000,
+    "versionHash": "0.2.0",
     "bundled": true,
-    "repoUrl": "https://github.com/tsimoshka/zed-theme-alabaster.git",
-    "repoStars": 4,
+    "repoUrl": "https://github.com/huacnlee/zed-theme-macos-classic",
+    "repoStars": 60,
     "theme": {
       "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
-      "name": "Alabaster",
-      "author": "Vitali Tsimoshka (theme originally by Nikita Prokopov)",
+      "name": "macOS Classic",
+      "author": "huacnlee",
       "themes": [
         {
-          "name": "Alabaster",
+          "name": "macOS Classic Light",
           "appearance": "light",
           "style": {
-            "border": null,
-            "border.variant": null,
-            "border.focused": "#CCCCCC",
-            "border.selected": null,
-            "border.transparent": null,
-            "border.disabled": null,
-            "elevated_surface.background": null,
-            "surface.background": "#F0F0F0",
-            "background": "#F7F7F7",
-            "element.background": null,
-            "element.hover": null,
+            "border": "#D2D2D2",
+            "border.variant": "#E0E0E0",
+            "border.focused": "#eeeeee",
+            "border.selected": "#DADADA",
+            "border.transparent": "#DADADA",
+            "border.disabled": "#DCDBDA",
+            "elevated_surface.background": "#F7F7F7",
+            "surface.background": "#E0E0E0",
+            "background": "#ffffff",
+            "element.background": "#E0E0E0",
+            "element.hover": "#D0D0D0",
             "element.active": null,
-            "element.selected": "#DDDDDD",
+            "element.selected": "#C7DEFF",
             "element.disabled": null,
             "drop_target.background": null,
             "ghost_element.background": null,
-            "ghost_element.hover": null,
+            "ghost_element.hover": "#D7D5D577",
             "ghost_element.active": null,
-            "ghost_element.selected": "#DDDDDD",
+            "ghost_element.selected": "#E4E0E0",
+            "ghost_element.disabled": null,
+            "text": "#000000",
+            "text.muted": "#505050",
+            "text.placeholder": "#929292",
+            "text.disabled": null,
+            "text.accent": "#1f6ae2",
+            "icon": null,
+            "icon.muted": null,
+            "icon.disabled": null,
+            "icon.placeholder": null,
+            "icon.accent": null,
+            "status_bar.background": "#E9E9E9",
+            "title_bar.background": "#FEFEFE",
+            "toolbar.background": "#FFFFFF",
+            "tab_bar.background": "#E9E9E9",
+            "tab.inactive_background": "#E9E9E9",
+            "tab.active_background": "#FFFFFF",
+            "search.match_background": "#CBCFDECC",
+            "panel.background": "#F9F9F9",
+            "panel.focused_border": null,
+            "pane.focused_border": null,
+            "scrollbar_thumb.background": "#C8C8C8AA",
+            "scrollbar.thumb.hover_background": "#C8C8C8AA",
+            "scrollbar.thumb.border": null,
+            "scrollbar.track.background": "#ffffff",
+            "scrollbar.track.border": null,
+            "editor.foreground": "#000000",
+            "editor.background": "#ffffff",
+            "editor.gutter.background": "#FFFFFF",
+            "editor.subheader.background": null,
+            "editor.active_line.background": "#F0F0F0",
+            "editor.highlighted_line.background": null,
+            "editor.line_number": "#929292",
+            "editor.active_line_number": "#000000",
+            "editor.invisible": "#acafb1ff",
+            "editor.wrap_guide": "#DCDBDA",
+            "editor.active_wrap_guide": "#DCDBDA",
+            "editor.document_highlight.read_background": "#C9CDD0BB",
+            "editor.document_highlight.write_background": "#acafb166",
+            "terminal.background": "#ffffff",
+            "terminal.foreground": "#000000",
+            "terminal.bright_foreground": null,
+            "terminal.dim_foreground": null,
+            "terminal.ansi.black": "#000000",
+            "terminal.ansi.bright_black": "#4A4A4A",
+            "terminal.ansi.dim_black": null,
+            "terminal.ansi.red": "#C5060B",
+            "terminal.ansi.bright_red": "#D9564E",
+            "terminal.ansi.dim_red": null,
+            "terminal.ansi.green": "#277F2B",
+            "terminal.ansi.bright_green": "#35BD33",
+            "terminal.ansi.dim_green": null,
+            "terminal.ansi.yellow": "#8E7823",
+            "terminal.ansi.bright_yellow": "#BDA400",
+            "terminal.ansi.dim_yellow": null,
+            "terminal.ansi.blue": "#282BFF",
+            "terminal.ansi.bright_blue": "#5685F4",
+            "terminal.ansi.dim_blue": null,
+            "terminal.ansi.magenta": "#AE30C2",
+            "terminal.ansi.bright_magenta": "#D75CE7",
+            "terminal.ansi.dim_magenta": null,
+            "terminal.ansi.cyan": "#00767C",
+            "terminal.ansi.bright_cyan": "#20B1C9",
+            "terminal.ansi.dim_cyan": null,
+            "terminal.ansi.white": "#ffffff",
+            "terminal.ansi.bright_white": "#999999",
+            "terminal.ansi.dim_white": null,
+            "link_text.hover": null,
+            "conflict": "#C5060B",
+            "conflict.background": null,
+            "conflict.border": null,
+            "created": null,
+            "created.background": "#e5ffe9",
+            "created.border": null,
+            "deleted": null,
+            "deleted.background": "#FBEAE5",
+            "deleted.border": null,
+            "error": null,
+            "error.background": "#FBEAE5",
+            "error.border": "#EC9F89",
+            "hidden": "#6D6D6D",
+            "hidden.background": null,
+            "hidden.border": null,
+            "hint": null,
+            "hint.background": "#E5F2FF",
+            "hint.border": "#99CCFF",
+            "ignored": null,
+            "ignored.background": null,
+            "ignored.border": null,
+            "info": null,
+            "info.background": "#E5EAFF",
+            "info.border": "#8DA1FF",
+            "modified": "#1642FF",
+            "modified.background": "#fff2e5",
+            "modified.border": null,
+            "predictive": "#A4ABB6",
+            "predictive.background": null,
+            "predictive.border": null,
+            "renamed": null,
+            "renamed.background": null,
+            "renamed.border": null,
+            "success": null,
+            "success.background": "#E5FFE5",
+            "success.border": null,
+            "unreachable": null,
+            "unreachable.background": null,
+            "unreachable.border": null,
+            "warning": "#C99401",
+            "warning.background": "#FFFBE5",
+            "warning.border": "#D9CC89",
+            "players": [
+              {
+                "cursor": "#3b9ee5ff",
+                "background": "#3b9ee5ff",
+                "selection": "#3b9ee53d"
+              },
+              {
+                "cursor": "#55b4d3ff",
+                "background": "#55b4d3ff",
+                "selection": "#55b4d33d"
+              },
+              {
+                "cursor": "#f98d3fff",
+                "background": "#f98d3fff",
+                "selection": "#f98d3f3d"
+              },
+              {
+                "cursor": "#a37accff",
+                "background": "#a37accff",
+                "selection": "#a37acc3d"
+              },
+              {
+                "cursor": "#4dbf99ff",
+                "background": "#4dbf99ff",
+                "selection": "#4dbf993d"
+              },
+              {
+                "cursor": "#ef7271ff",
+                "background": "#ef7271ff",
+                "selection": "#ef72713d"
+              },
+              {
+                "cursor": "#f1ad49ff",
+                "background": "#f1ad49ff",
+                "selection": "#f1ad493d"
+              },
+              {
+                "cursor": "#85b304ff",
+                "background": "#85b304ff",
+                "selection": "#85b3043d"
+              }
+            ],
+            "syntax": {
+              "attribute": {
+                "color": "#957931",
+                "font_style": null,
+                "font_weight": null
+              },
+              "boolean": {
+                "color": "#C5060B",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment": {
+                "color": "#007fff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment.doc": {
+                "color": "#007fff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constant": {
+                "color": "#C5060B",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constructor": {
+                "color": "#0433ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "embedded": {
+                "color": "#333333",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function": {
+                "color": "#0000A2",
+                "font_style": null,
+                "font_weight": null
+              },
+              "keyword": {
+                "color": "#0433ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "link_text": {
+                "color": "#0000A2",
+                "font_style": "normal",
+                "font_weight": null
+              },
+              "link_uri": {
+                "color": "#6A7293",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "number": {
+                "color": "#0433ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string": {
+                "color": "#036A07",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.escape": {
+                "color": "#036A07",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.regex": {
+                "color": "#036A07",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special": {
+                "color": "#d21f07",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special.symbol": {
+                "color": "#d21f07",
+                "font_style": null,
+                "font_weight": null
+              },
+              "tag": {
+                "color": "#0433ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "text.literal": {
+                "color": "#6F42C1",
+                "font_style": null,
+                "font_weight": null
+              },
+              "title": {
+                "color": "#0433FF",
+                "font_style": null,
+                "font_weight": null
+              },
+              "type": {
+                "color": "#6f42c1",
+                "font_style": null,
+                "font_weight": null
+              },
+              "property": {
+                "color": "#333333",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable": {
+                "color": "#333333",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable.special": {
+                "color": "#C5060B",
+                "font_style": null,
+                "font_weight": null
+              }
+            }
+          }
+        },
+        {
+          "name": "macOS Classic Dark",
+          "appearance": "dark",
+          "style": {
+            "border": "#404040",
+            "border.variant": "#3A3A3A",
+            "border.focused": "#3A3A3AFF",
+            "border.selected": "#3A3A3A",
+            "border.transparent": "#3A3A3A",
+            "border.disabled": "#3A3A3A",
+            "elevated_surface.background": "#1E1D1E",
+            "surface.background": "#1E1D1E",
+            "background": "#131313",
+            "element.background": "#474646",
+            "element.hover": "#353436",
+            "element.active": "#353436",
+            "element.selected": "#353436",
+            "element.disabled": null,
+            "drop_target.background": null,
+            "ghost_element.background": null,
+            "ghost_element.hover": "#353436",
+            "ghost_element.active": null,
+            "ghost_element.selected": "#474646",
+            "ghost_element.disabled": null,
+            "text": "#CACCCA",
+            "text.muted": "#9E9E9E",
+            "text.placeholder": null,
+            "text.disabled": null,
+            "text.accent": null,
+            "icon": null,
+            "icon.muted": null,
+            "icon.disabled": null,
+            "icon.placeholder": null,
+            "icon.accent": null,
+            "status_bar.background": "#363636",
+            "title_bar.background": "#323232",
+            "toolbar.background": "#131313",
+            "tab_bar.background": "#232323",
+            "tab.inactive_background": "#232323",
+            "tab.active_background": "#131313",
+            "search.match_background": null,
+            "panel.background": "#1E1D1E",
+            "panel.focused_border": null,
+            "pane.focused_border": null,
+            "scrollbar_thumb.background": "#4C4D4DAA",
+            "scrollbar.thumb.hover_background": "#4C4D4D",
+            "scrollbar.thumb.border": null,
+            "scrollbar.track.background": "#131313",
+            "scrollbar.track.border": null,
+            "editor.foreground": "#DDDDDD",
+            "editor.background": "#131313",
+            "editor.gutter.background": "#131313",
+            "editor.subheader.background": null,
+            "editor.active_line.background": "#272727",
+            "editor.highlighted_line.background": null,
+            "editor.line_number": "#8F8F8F",
+            "editor.active_line_number": "#DDDDDD",
+            "editor.invisible": null,
+            "editor.wrap_guide": "#3A3A3A",
+            "editor.active_wrap_guide": "#3A3A3A",
+            "editor.document_highlight.read_background": null,
+            "editor.document_highlight.write_background": null,
+            "terminal.background": null,
+            "terminal.foreground": null,
+            "terminal.bright_foreground": null,
+            "terminal.dim_foreground": null,
+            "terminal.ansi.black": "#E8E4CF",
+            "terminal.ansi.bright_black": "#57564F",
+            "terminal.ansi.dim_black": null,
+            "terminal.ansi.red": "#A8473B",
+            "terminal.ansi.bright_red": "#DD6F61",
+            "terminal.ansi.dim_red": null,
+            "terminal.ansi.green": "#76BA53",
+            "terminal.ansi.bright_green": "#9DE478",
+            "terminal.ansi.dim_green": null,
+            "terminal.ansi.yellow": "#E1D797",
+            "terminal.ansi.bright_yellow": "#857F5C",
+            "terminal.ansi.dim_yellow": null,
+            "terminal.ansi.blue": "#3D6EB6",
+            "terminal.ansi.bright_blue": "#81A9F6",
+            "terminal.ansi.dim_blue": null,
+            "terminal.ansi.magenta": "#AE30C2",
+            "terminal.ansi.bright_magenta": "#D86DE9",
+            "terminal.ansi.dim_magenta": null,
+            "terminal.ansi.cyan": "#3DB6B0",
+            "terminal.ansi.bright_cyan": "#5BDFD8",
+            "terminal.ansi.dim_cyan": null,
+            "terminal.ansi.white": "#131313",
+            "terminal.ansi.bright_white": "#3A3A3A",
+            "terminal.ansi.dim_white": null,
+            "link_text.hover": null,
+            "conflict": "#D2602D",
+            "conflict.background": null,
+            "conflict.border": null,
+            "created": null,
+            "created.background": "#0C4619",
+            "created.border": null,
+            "deleted": null,
+            "deleted.background": "#46190C",
+            "deleted.border": null,
+            "error": null,
+            "error.background": "#46190C",
+            "error.border": "#802207",
+            "hidden": "#9E9E9E",
+            "hidden.background": null,
+            "hidden.border": null,
+            "hint": null,
+            "hint.background": "#0C194D",
+            "hint.border": "#082190",
+            "ignored": null,
+            "ignored.background": null,
+            "ignored.border": null,
+            "info": null,
+            "info.background": "#0C194D",
+            "info.border": "#082190",
+            "modified": "#B0A878",
+            "modified.background": "#3A310E",
+            "modified.border": null,
+            "predictive": "#5D5945",
+            "predictive.background": null,
+            "predictive.border": null,
+            "renamed": null,
+            "renamed.background": null,
+            "renamed.border": null,
+            "success": null,
+            "success.background": "#0C4619",
+            "success.border": null,
+            "unreachable": null,
+            "unreachable.background": null,
+            "unreachable.border": null,
+            "warning": null,
+            "warning.background": "#3A310E",
+            "warning.border": "#7B6508",
+            "players": [
+              {
+                "cursor": "#72cffeff",
+                "background": "#72cffeff",
+                "selection": "#72cffe3d"
+              },
+              {
+                "cursor": "#5bcde5ff",
+                "background": "#5bcde5ff",
+                "selection": "#5bcde53d"
+              },
+              {
+                "cursor": "#fead66ff",
+                "background": "#fead66ff",
+                "selection": "#fead663d"
+              },
+              {
+                "cursor": "#debffeff",
+                "background": "#debffeff",
+                "selection": "#debffe3d"
+              },
+              {
+                "cursor": "#95e5cbff",
+                "background": "#95e5cbff",
+                "selection": "#95e5cb3d"
+              },
+              {
+                "cursor": "#f18779ff",
+                "background": "#f18779ff",
+                "selection": "#f187793d"
+              },
+              {
+                "cursor": "#fecf72ff",
+                "background": "#fecf72ff",
+                "selection": "#fecf723d"
+              },
+              {
+                "cursor": "#d5fe80ff",
+                "background": "#d5fe80ff",
+                "selection": "#d5fe803d"
+              }
+            ],
+            "syntax": {
+              "attribute": {
+                "color": "#be9a52",
+                "font_style": null,
+                "font_weight": null
+              },
+              "boolean": {
+                "color": "#E1D797",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment": {
+                "color": "#9E9E9E",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment.doc": {
+                "color": "#9E9E9E",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constant": {
+                "color": "#E1D797",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constructor": {
+                "color": "#b5af9a",
+                "font_style": null,
+                "font_weight": null
+              },
+              "embedded": {
+                "color": "#CACCCA",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function": {
+                "color": "#E1D797",
+                "font_style": null,
+                "font_weight": null
+              },
+              "keyword": {
+                "color": "#E19773",
+                "font_style": null,
+                "font_weight": null
+              },
+              "link_text": {
+                "color": "#A86D3B",
+                "font_style": "normal",
+                "font_weight": null
+              },
+              "link_uri": {
+                "color": "#6F6D66",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "number": {
+                "color": "#E19773",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string": {
+                "color": "#76BA53",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.escape": {
+                "color": "#76BA53",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.regex": {
+                "color": "#76BA53",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special": {
+                "color": "#E1D797",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special.symbol": {
+                "color": "#E1D797",
+                "font_style": null,
+                "font_weight": null
+              },
+              "tag": {
+                "color": "#b5af9a",
+                "font_style": null,
+                "font_weight": null
+              },
+              "text.literal": {
+                "color": "#E1D797",
+                "font_style": null,
+                "font_weight": null
+              },
+              "title": {
+                "color": "#A76D3B",
+                "font_style": null,
+                "font_weight": 600
+              },
+              "type": {
+                "color": "#A86D3B",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable.special": {
+                "color": "#E19773",
+                "font_style": null,
+                "font_weight": null
+              }
+            }
+          }
+        },
+        {
+          "name": "macOS Classic Dark2",
+          "appearance": "dark",
+          "style": {
+            "border": "#3A3A3A",
+            "border.variant": "#3A3A3A",
+            "border.focused": "#3A3A3AFF",
+            "border.selected": "#3A3A3A",
+            "border.transparent": "#3A3A3A",
+            "border.disabled": "#3A3A3A",
+            "elevated_surface.background": "#1E1D1E",
+            "surface.background": "#1E1D1E",
+            "background": "#131313",
+            "element.background": "#282828",
+            "element.hover": "#252426",
+            "element.active": "#252426",
+            "element.selected": "#353436",
+            "element.disabled": null,
+            "drop_target.background": null,
+            "ghost_element.background": null,
+            "ghost_element.hover": "#E8E4CF11",
+            "ghost_element.active": null,
+            "ghost_element.selected": "#E8E4CF22",
+            "ghost_element.disabled": null,
+            "text": "#CACCCA",
+            "text.muted": "#9E9E9E",
+            "text.placeholder": null,
+            "text.disabled": null,
+            "text.accent": null,
+            "icon": null,
+            "icon.muted": null,
+            "icon.disabled": null,
+            "icon.placeholder": null,
+            "icon.accent": null,
+            "status_bar.background": "#262626",
+            "title_bar.background": "#292929",
+            "toolbar.background": "#131313",
+            "tab_bar.background": "#232323",
+            "tab.inactive_background": "#232323",
+            "tab.active_background": "#101010",
+            "search.match_background": null,
+            "panel.background": "#1E1D1E",
+            "panel.focused_border": null,
+            "pane.focused_border": null,
+            "scrollbar_thumb.background": "#4C4D4DAA",
+            "scrollbar.thumb.hover_background": "#4C4D4D",
+            "scrollbar.thumb.border": null,
+            "scrollbar.track.background": "#131313",
+            "scrollbar.track.border": null,
+            "editor.foreground": "#E8E4CF",
+            "editor.background": "#131313",
+            "editor.gutter.background": "#131313",
+            "editor.subheader.background": null,
+            "editor.active_line.background": "#272727",
+            "editor.highlighted_line.background": null,
+            "editor.line_number": "#8F8F8F",
+            "editor.active_line_number": "#E8E4CF",
+            "editor.invisible": null,
+            "editor.wrap_guide": "#3A3A3A",
+            "editor.active_wrap_guide": "#3A3A3A",
+            "editor.document_highlight.read_background": null,
+            "editor.document_highlight.write_background": null,
+            "terminal.background": null,
+            "terminal.foreground": null,
+            "terminal.bright_foreground": null,
+            "terminal.dim_foreground": null,
+            "terminal.ansi.black": "#E8E4CF",
+            "terminal.ansi.bright_black": "#57564F",
+            "terminal.ansi.dim_black": null,
+            "terminal.ansi.red": "#D73737",
+            "terminal.ansi.bright_red": "#E66969",
+            "terminal.ansi.dim_red": null,
+            "terminal.ansi.green": "#76BA53",
+            "terminal.ansi.bright_green": "#9DE478",
+            "terminal.ansi.dim_green": null,
+            "terminal.ansi.yellow": "#AE9513",
+            "terminal.ansi.bright_yellow": "#705F00",
+            "terminal.ansi.dim_yellow": null,
+            "terminal.ansi.blue": "#3F74DA",
+            "terminal.ansi.bright_blue": "#81A9F6",
+            "terminal.ansi.dim_blue": null,
+            "terminal.ansi.magenta": "#AE30C2",
+            "terminal.ansi.bright_magenta": "#D86DE9",
+            "terminal.ansi.dim_magenta": null,
+            "terminal.ansi.cyan": "#37D0D7",
+            "terminal.ansi.bright_cyan": "#69DDE6",
+            "terminal.ansi.dim_cyan": null,
+            "terminal.ansi.white": "#131313",
+            "terminal.ansi.bright_white": "#3A3A3A",
+            "terminal.ansi.dim_white": null,
+            "link_text.hover": null,
+            "conflict": "#AE9513",
+            "conflict.background": null,
+            "conflict.border": null,
+            "created": null,
+            "created.background": "#0C4619",
+            "created.border": null,
+            "deleted": null,
+            "deleted.background": "#46190C",
+            "deleted.border": null,
+            "error": null,
+            "error.background": "#46190C",
+            "error.border": "#802207",
+            "hidden": "#9E9E9E",
+            "hidden.background": null,
+            "hidden.border": null,
+            "hint": null,
+            "hint.background": "#0C194D",
+            "hint.border": "#082190",
+            "ignored": null,
+            "ignored.background": null,
+            "ignored.border": null,
+            "info": null,
+            "info.background": "#0C194D",
+            "info.border": "#082190",
+            "modified": "#B0A878",
+            "modified.background": "#3A310E",
+            "modified.border": null,
+            "predictive": "#5D5945",
+            "predictive.background": null,
+            "predictive.border": null,
+            "renamed": null,
+            "renamed.background": null,
+            "renamed.border": null,
+            "success": null,
+            "success.background": "#0C4619",
+            "success.border": null,
+            "unreachable": null,
+            "unreachable.background": null,
+            "unreachable.border": null,
+            "warning": null,
+            "warning.background": "#3A310E",
+            "warning.border": "#7B6508",
+            "players": [
+              {
+                "cursor": "#72cffeff",
+                "background": "#72cffeff",
+                "selection": "#72cffe3d"
+              },
+              {
+                "cursor": "#5bcde5ff",
+                "background": "#5bcde5ff",
+                "selection": "#5bcde53d"
+              },
+              {
+                "cursor": "#fead66ff",
+                "background": "#fead66ff",
+                "selection": "#fead663d"
+              },
+              {
+                "cursor": "#debffeff",
+                "background": "#debffeff",
+                "selection": "#debffe3d"
+              },
+              {
+                "cursor": "#95e5cbff",
+                "background": "#95e5cbff",
+                "selection": "#95e5cb3d"
+              },
+              {
+                "cursor": "#f18779ff",
+                "background": "#f18779ff",
+                "selection": "#f187793d"
+              },
+              {
+                "cursor": "#fecf72ff",
+                "background": "#fecf72ff",
+                "selection": "#fecf723d"
+              },
+              {
+                "cursor": "#d5fe80ff",
+                "background": "#d5fe80ff",
+                "selection": "#d5fe803d"
+              }
+            ],
+            "syntax": {
+              "attribute": {
+                "color": "#AE9513",
+                "font_style": null,
+                "font_weight": null
+              },
+              "boolean": {
+                "color": "#705f00",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment": {
+                "color": "#9E9E9E",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment.doc": {
+                "color": "#9E9E9E",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constant": {
+                "color": "#705f00",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constructor": {
+                "color": "#9a9576",
+                "font_style": null,
+                "font_weight": null
+              },
+              "embedded": {
+                "color": "#CACCCA",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function": {
+                "color": "#c0b298",
+                "font_style": null,
+                "font_weight": null
+              },
+              "keyword": {
+                "color": "#AE9513",
+                "font_style": null,
+                "font_weight": null
+              },
+              "link_text": {
+                "color": "#CEB63D",
+                "font_style": "normal",
+                "font_weight": null
+              },
+              "link_uri": {
+                "color": "#6E6C65",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "number": {
+                "color": "#AE9513",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string": {
+                "color": "#76BA53",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.escape": {
+                "color": "#76BA53",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.regex": {
+                "color": "#76BA53",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special": {
+                "color": "#7D7A68",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special.symbol": {
+                "color": "#7D7A68",
+                "font_style": null,
+                "font_weight": null
+              },
+              "tag": {
+                "color": "#9a9576",
+                "font_style": null,
+                "font_weight": null
+              },
+              "text.literal": {
+                "color": "#8C7701",
+                "font_style": null,
+                "font_weight": null
+              },
+              "title": {
+                "color": "#D73737",
+                "font_style": null,
+                "font_weight": null
+              },
+              "type": {
+                "color": "#D73737",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable.special": {
+                "color": "#AE9513"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "userId": null,
+    "installCount": 95351
+  },
+  {
+    "id": "tokyo-night",
+    "name": "Tokyo Night Themes",
+    "author": "ssaunderss",
+    "updatedDate": 1724713247000,
+    "versionHash": "0.4.0",
+    "bundled": true,
+    "repoUrl": "https://github.com/ssaunderss/zed-tokyo-night",
+    "repoStars": 26,
+    "theme": {
+      "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
+      "name": "Tokyo Night",
+      "author": "Tokyo Night: Zed Theme Importer",
+      "themes": [
+        {
+          "name": "Tokyo Night",
+          "appearance": "dark",
+          "style": {
+            "border": "#101014",
+            "border.variant": "#101014",
+            "border.focused": "#545c7e33",
+            "border.selected": "#101014",
+            "border.transparent": "#101014",
+            "border.disabled": "#101014",
+            "elevated_surface.background": "#14141b",
+            "surface.background": "#16161e",
+            "background": "#1a1b26",
+            "element.background": "#1a1b26",
+            "element.hover": "#565f89",
+            "element.active": "#9aa5ce",
+            "element.selected": "#565f89",
+            "element.disabled": "#414868",
+            "drop_target.background": "#1e202e",
+            "ghost_element.background": "#1a1b26",
+            "ghost_element.hover": "#565f89",
+            "ghost_element.active": "#9aa5ce",
+            "ghost_element.selected": "#565f89",
+            "ghost_element.disabled": "#414868",
+            "text": "#a9b1d6",
+            "text.muted": "#787c99",
+            "text.placeholder": "#787c99",
+            "text.disabled": "#414868",
+            "text.accent": "#7dcfff",
+            "icon": "#787c99",
+            "icon.muted": "#787c99",
+            "icon.disabled": "#414868",
+            "icon.placeholder": "#565f89",
+            "icon.accent": "#7dcfff",
+            "status_bar.background": "#16161e",
+            "title_bar.background": "#16161e",
+            "title_bar.inactive_background": "#16161e",
+            "toolbar.background": "#16161e",
+            "tab_bar.background": "#16161e",
+            "tab.inactive_background": "#16161e",
+            "tab.active_background": "#414868",
+            "search.match_background": "#414868",
+            "panel.background": "#16161e",
+            "panel.focused_border": null,
+            "pane.focused_border": null,
+            "scrollbar.thumb.background": "#41486880",
+            "scrollbar.thumb.hover_background": "#414868",
+            "scrollbar.thumb.border": "#414868",
+            "scrollbar.track.background": "#1a1b2680",
+            "scrollbar.track.border": "#101014",
+            "editor.foreground": "#a9b1d6",
+            "editor.background": "#1a1b26",
+            "editor.gutter.background": "#1a1b26",
+            "editor.subheader.background": "#1a1b26",
+            "editor.active_line.background": "#1e202e",
+            "editor.highlighted_line.background": "#1e202e",
+            "editor.line_number": "#363b54",
+            "editor.active_line_number": "#a9b1d6",
+            "editor.invisible": null,
+            "editor.wrap_guide": "#101014",
+            "editor.active_wrap_guide": "#101014",
+            "editor.document_highlight.read_background": "#363b54",
+            "editor.document_highlight.write_background": "#363b54",
+            "terminal.background": "#16161e",
+            "terminal.foreground": null,
+            "terminal.bright_foreground": null,
+            "terminal.dim_foreground": null,
+            "terminal.ansi.black": "#363b54",
+            "terminal.ansi.bright_black": "#363b54",
+            "terminal.ansi.dim_black": null,
+            "terminal.ansi.red": "#f7768e",
+            "terminal.ansi.bright_red": "#f7768e",
+            "terminal.ansi.dim_red": null,
+            "terminal.ansi.green": "#73daca",
+            "terminal.ansi.bright_green": "#41a6b5",
+            "terminal.ansi.dim_green": null,
+            "terminal.ansi.yellow": "#e0af68",
+            "terminal.ansi.bright_yellow": "#e0af68",
+            "terminal.ansi.dim_yellow": null,
+            "terminal.ansi.blue": "#7aa2f7",
+            "terminal.ansi.bright_blue": "#7aa2f7",
+            "terminal.ansi.dim_blue": null,
+            "terminal.ansi.magenta": "#bb9af7",
+            "terminal.ansi.bright_magenta": "#bb9af7",
+            "terminal.ansi.dim_magenta": null,
+            "terminal.ansi.cyan": "#7dcfff",
+            "terminal.ansi.bright_cyan": "#7dcfff",
+            "terminal.ansi.dim_cyan": null,
+            "terminal.ansi.white": "#787c99",
+            "terminal.ansi.bright_white": "#acb0d0",
+            "terminal.ansi.dim_white": null,
+            "link_text.hover": "#7dcfff",
+            "conflict": "#bb9af7",
+            "conflict.background": "#1a1b26",
+            "conflict.border": "#414868",
+            "created": "#9ece6a",
+            "created.background": "#1a1b26",
+            "created.border": "#414868",
+            "deleted": "#f7768e",
+            "deleted.background": "#1a1b26",
+            "deleted.border": "#414868",
+            "error": "#f7768e",
+            "error.background": "#1a1b26",
+            "error.border": "#414868",
+            "hidden": "#787c99",
+            "hidden.background": "#1a1b26",
+            "hidden.border": "#414868",
+            "hint": "#51597d",
+            "hint.background": "#1a1b26",
+            "hint.border": "#414868",
+            "ignored": "#515670",
+            "ignored.background": "#1a1b26",
+            "ignored.border": "#414868",
+            "info": "#0da0ba",
+            "info.background": "#1a1b26",
+            "info.border": "#414868",
+            "modified": "#e0af68",
+            "modified.background": "#1a1b26",
+            "modified.border": "#414868",
+            "predictive": "#51597d",
+            "predictive.background": "#1a1b26",
+            "predictive.border": "#414868",
+            "renamed": "#9ece6a",
+            "renamed.background": "#1a1b26",
+            "renamed.border": "#414868",
+            "success": "#9ece6a",
+            "success.background": "#1a1b26",
+            "success.border": "#414868",
+            "unreachable": "#f7768e",
+            "unreachable.background": "#1a1b26",
+            "unreachable.border": "#414868",
+            "warning": "#e0af68",
+            "warning.background": "#1a1b26",
+            "warning.border": "#414868",
+            "players": [
+              {
+                "cursor": "#7c7f93",
+                "background": "#7c7f93",
+                "selection": "#7c7f93"
+              }
+            ],
+            "syntax": {
+              "attribute": {
+                "color": "#bb9af7",
+                "font_style": null,
+                "font_weight": null
+              },
+              "boolean": {
+                "color": "#ff9e64",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment": {
+                "color": "#51597d",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment.doc": {
+                "color": "#51597d",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constant": {
+                "color": "#ff9e64",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constructor": {
+                "color": "#f7768e",
+                "font_style": null,
+                "font_weight": null
+              },
+              "emphasis": {
+                "color": "#f7768e",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "emphasis.strong": {
+                "color": "#f7768e",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "function": {
+                "color": "#7aa2f7",
+                "font_style": null,
+                "font_weight": null
+              },
+              "keyword": {
+                "color": "#bb9af7",
+                "font_style": null,
+                "font_weight": null
+              },
+              "label": {
+                "color": "#c0caf5",
+                "font_style": null,
+                "font_weight": null
+              },
+              "link_text": {
+                "color": "#73daca",
+                "font_style": null,
+                "font_weight": null
+              },
+              "link_uri": {
+                "color": "#73daca",
+                "font_style": null,
+                "font_weight": null
+              },
+              "number": {
+                "color": "#ff9e64",
+                "font_style": null,
+                "font_weight": null
+              },
+              "operator": {
+                "color": "#89ddff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "preproc": {
+                "color": "#73daca",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation": {
+                "color": "#89ddff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.bracket": {
+                "color": "#89ddff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.delimiter": {
+                "color": "#89ddff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.list_marker": {
+                "color": "#89ddff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.special": {
+                "color": "#89ddff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string": {
+                "color": "#9ece6a",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.escape": {
+                "color": "#bb9af7",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.regex": {
+                "color": "#9ece6a",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special": {
+                "color": "#9ece6a",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special.symbol": {
+                "color": "#9ece6a",
+                "font_style": null,
+                "font_weight": null
+              },
+              "tag": {
+                "color": "#f7768e",
+                "font_style": null,
+                "font_weight": null
+              },
+              "text.literal": {
+                "color": "#9ece6a",
+                "font_style": null,
+                "font_weight": null
+              },
+              "title": {
+                "color": "#ff9e64",
+                "font_style": null,
+                "font_weight": null
+              },
+              "type": {
+                "color": "#0db9d7",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable": {
+                "color": "#c0caf5",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable.special": {
+                "color": "#f7768e",
+                "font_style": null,
+                "font_weight": null
+              }
+            }
+          }
+        },
+        {
+          "name": "Tokyo Night Light",
+          "appearance": "light",
+          "style": {
+            "border": "#c1c2c7",
+            "border.variant": "#c1c2c7",
+            "border.focused": "#82859433",
+            "border.selected": "#c1c2c7",
+            "border.transparent": "#c1c2c7",
+            "border.disabled": "#c1c2c7",
+            "elevated_surface.background": "#d5d6db",
+            "surface.background": "#cbccd1",
+            "background": "#d5d6db",
+            "element.background": "#d5d6db",
+            "element.hover": "#9699a3",
+            "element.active": "#565a6e",
+            "element.selected": "#9699a3",
+            "element.disabled": "#0f0f14",
+            "drop_target.background": "#c1c2c7",
+            "ghost_element.background": "#d5d6db",
+            "ghost_element.hover": "#9699a3",
+            "ghost_element.active": "#565a6e",
+            "ghost_element.selected": "#9699a3",
+            "ghost_element.disabled": "#0f0f14",
+            "text": "#343b58",
+            "text.muted": "#4c505e",
+            "text.placeholder": "#4c505e",
+            "text.disabled": "#0f0f14",
+            "text.accent": "0f4b6e",
+            "icon": "#4c505e",
+            "icon.muted": "#4c505e",
+            "icon.disabled": "#0f0f14",
+            "icon.placeholder": "#9699a3",
+            "icon.accent": "#0f4b6e",
+            "status_bar.background": "#cbccd1",
+            "title_bar.background": "#cbccd1",
+            "title_bar.inactive_background": "#cbccd1",
+            "toolbar.background": "#cbccd1",
+            "tab_bar.background": "#cbccd1",
+            "tab.inactive_background": "#cbccd1",
+            "tab.active_background": "#9699a3",
+            "search.match_background": "#9699a3",
+            "panel.background": "#cbccd1",
+            "panel.focused_border": null,
+            "pane.focused_border": null,
+            "scrollbar.thumb.background": "#9699a380",
+            "scrollbar.thumb.hover_background": "#9699a3",
+            "scrollbar.thumb.border": "#9699a3",
+            "scrollbar.track.background": "#d5d6db80",
+            "scrollbar.track.border": "#c1c2c7",
+            "editor.foreground": "#343b59",
+            "editor.background": "#d5d6db",
+            "editor.gutter.background": "#d5d6db",
+            "editor.subheader.background": "#d5d6db",
+            "editor.active_line.background": "#dcdee3",
+            "editor.highlighted_line.background": "#dcdee3",
+            "editor.line_number": "#9da0ab",
+            "editor.active_line_number": "#343b59",
+            "editor.invisible": null,
+            "editor.wrap_guide": "#c1c2c7",
+            "editor.active_wrap_guide": "#c1c2c7",
+            "editor.document_highlight.read_background": "#9da0ab",
+            "editor.document_highlight.write_background": "#9da0ab",
+            "terminal.background": "#cbccd1",
+            "terminal.foreground": null,
+            "terminal.bright_foreground": null,
+            "terminal.dim_foreground": null,
+            "terminal.ansi.black": "#0f0f14",
+            "terminal.ansi.bright_black": "#0f0f14",
+            "terminal.ansi.dim_black": null,
+            "terminal.ansi.red": "#8c4351",
+            "terminal.ansi.bright_red": "#8c4351",
+            "terminal.ansi.dim_red": null,
+            "terminal.ansi.green": "#33635c",
+            "terminal.ansi.bright_green": "#33635c",
+            "terminal.ansi.dim_green": null,
+            "terminal.ansi.yellow": "#8f5e15",
+            "terminal.ansi.bright_yellow": "#8f5e15",
+            "terminal.ansi.dim_yellow": null,
+            "terminal.ansi.blue": "#34548a",
+            "terminal.ansi.bright_blue": "#34548a",
+            "terminal.ansi.dim_blue": null,
+            "terminal.ansi.magenta": "#5a4a78",
+            "terminal.ansi.bright_magenta": "#5a4a78",
+            "terminal.ansi.dim_magenta": null,
+            "terminal.ansi.cyan": "#0f4b6e",
+            "terminal.ansi.bright_cyan": "#0f4b6e",
+            "terminal.ansi.dim_cyan": null,
+            "terminal.ansi.white": "#828594",
+            "terminal.ansi.bright_white": "#828594",
+            "terminal.ansi.dim_white": null,
+            "link_text.hover": "#4c505e",
+            "conflict": "#5a4a78",
+            "conflict.background": "#d5d6db",
+            "conflict.border": "#343b58",
+            "created": "#485e30",
+            "created.background": "#d5d6db",
+            "created.border": "#343b58",
+            "deleted": "#8c4351",
+            "deleted.background": "#d5d6db",
+            "deleted.border": "#343b58",
+            "error": "#8c4351",
+            "error.background": "#d5d6db",
+            "error.border": "#343b58",
+            "hidden": "#4c505e",
+            "hidden.background": "#d5d6db",
+            "hidden.border": "#343b58",
+            "hint": "#634f30",
+            "hint.background": "#d5d6db",
+            "hint.border": "#343b58",
+            "ignored": "#828594",
+            "ignored.background": "#d5d6db",
+            "ignored.border": "#343b58",
+            "info": "#0da0ba",
+            "info.background": "#d5d6db",
+            "info.border": "#343b58",
+            "modified": "#8f5e15",
+            "modified.background": "#d5d6db",
+            "modified.border": "#343b58",
+            "predictive": "#634f30",
+            "predictive.background": "#d5d6db",
+            "predictive.border": "#343b58",
+            "renamed": "#485e30",
+            "renamed.background": "#d5d6db",
+            "renamed.border": "#343b58",
+            "success": "#485e30",
+            "success.background": "#d5d6db",
+            "success.border": "#343b58",
+            "unreachable": "#8c4351",
+            "unreachable.background": "#d5d6db",
+            "unreachable.border": "#343b58",
+            "warning": "#8f5e15",
+            "warning.background": "#d5d6db",
+            "warning.border": "#343b58",
+            "players": [
+              {
+                "cursor": "#7c7f93",
+                "background": "#7c7f93",
+                "selection": "#7c7f93"
+              }
+            ],
+            "syntax": {
+              "attribute": {
+                "color": "#5a4a78",
+                "font_style": null,
+                "font_weight": null
+              },
+              "boolean": {
+                "color": "#965027",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment": {
+                "color": "#9699a3",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment.doc": {
+                "color": "#9699a3",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constant": {
+                "color": "#965027",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constructor": {
+                "color": "#8c4351",
+                "font_style": null,
+                "font_weight": null
+              },
+              "emphasis": {
+                "color": "#8c4351",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "emphasis.strong": {
+                "color": "#8c4351",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "function": {
+                "color": "#34548a",
+                "font_style": null,
+                "font_weight": null
+              },
+              "keyword": {
+                "color": "#5a4a78",
+                "font_style": null,
+                "font_weight": null
+              },
+              "label": {
+                "color": "#343b58",
+                "font_style": null,
+                "font_weight": null
+              },
+              "link_text": {
+                "color": "#33635c",
+                "font_style": null,
+                "font_weight": null
+              },
+              "link_uri": {
+                "color": "#33635c",
+                "font_style": null,
+                "font_weight": null
+              },
+              "number": {
+                "color": "#965027",
+                "font_style": null,
+                "font_weight": null
+              },
+              "operator": {
+                "color": "#4c505e",
+                "font_style": null,
+                "font_weight": null
+              },
+              "preproc": {
+                "color": "#33635c",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation": {
+                "color": "#4c505e",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.bracket": {
+                "color": "#4c505e",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.delimiter": {
+                "color": "#4c505e",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.list_marker": {
+                "color": "#4c505e",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.special": {
+                "color": "#4c505e",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string": {
+                "color": "#485e30",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.escape": {
+                "color": "#5a4a78",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.regex": {
+                "color": "#485e30",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special": {
+                "color": "#485e30",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special.symbol": {
+                "color": "#485e30",
+                "font_style": null,
+                "font_weight": null
+              },
+              "tag": {
+                "color": "#8c4351",
+                "font_style": null,
+                "font_weight": null
+              },
+              "text.literal": {
+                "color": "#485e30",
+                "font_style": null,
+                "font_weight": null
+              },
+              "title": {
+                "color": "#965027",
+                "font_style": null,
+                "font_weight": null
+              },
+              "type": {
+                "color": "#166775",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable": {
+                "color": "#343b58",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable.special": {
+                "color": "#8c4351",
+                "font_style": null,
+                "font_weight": null
+              }
+            }
+          }
+        },
+        {
+          "name": "Tokyo Night Storm",
+          "appearance": "dark",
+          "style": {
+            "border": "#1b1e2e",
+            "border.variant": "#1b1e2e",
+            "border.focused": "#545c7e33",
+            "border.selected": "#1b1e2e",
+            "border.transparent": "#1b1e2e",
+            "border.disabled": "#1b1e2e",
+            "elevated_surface.background": "#1b1e2e",
+            "surface.background": "#1f2335",
+            "background": "#24283b",
+            "element.background": "#24283b",
+            "element.hover": "#565f89",
+            "element.active": "#9aa5ce",
+            "element.selected": "#565f89",
+            "element.disabled": "#414868",
+            "drop_target.background": "#1e202e",
+            "ghost_element.background": "#1a1b26",
+            "ghost_element.hover": "#565f89",
+            "ghost_element.active": "#9aa5ce",
+            "ghost_element.selected": "#565f89",
+            "ghost_element.disabled": "#414868",
+            "text": "#a9b1d6",
+            "text.muted": "#7982a9",
+            "text.placeholder": "#787c99",
+            "text.disabled": "#414868",
+            "text.accent": "#7dcfff",
+            "icon": "#787c99",
+            "icon.muted": "#787c99",
+            "icon.disabled": "#414868",
+            "icon.placeholder": "#565f89",
+            "icon.accent": "#7dcfff",
+            "status_bar.background": "#1f2335",
+            "title_bar.background": "#1f2335",
+            "title_bar.inactive_background": "#1f2335",
+            "toolbar.background": "#1f2335",
+            "tab_bar.background": "#1f2335",
+            "tab.inactive_background": "#1f2335",
+            "tab.active_background": "#414868",
+            "search.match_background": "#414868",
+            "panel.background": "#1f2335",
+            "panel.focused_border": null,
+            "pane.focused_border": null,
+            "scrollbar.thumb.background": "#41486880",
+            "scrollbar.thumb.hover_background": "#414868",
+            "scrollbar.thumb.border": "#414868",
+            "scrollbar.track.background": "#24283b80",
+            "scrollbar.track.border": "#1b1e2e",
+            "editor.foreground": "#a9b1d6",
+            "editor.background": "#24283b",
+            "editor.gutter.background": "#24283b",
+            "editor.subheader.background": "#24283b",
+            "editor.active_line.background": "#292e42",
+            "editor.highlighted_line.background": "#1e202e",
+            "editor.line_number": "#3b4261",
+            "editor.active_line_number": "#a9b1d6",
+            "editor.invisible": null,
+            "editor.wrap_guide": "#1b1e2e",
+            "editor.active_wrap_guide": "#1b1e2e",
+            "editor.document_highlight.read_background": "#363b54",
+            "editor.document_highlight.write_background": "#363b54",
+            "terminal.background": "#1f2335",
+            "terminal.foreground": null,
+            "terminal.bright_foreground": null,
+            "terminal.dim_foreground": null,
+            "terminal.ansi.black": "#414868",
+            "terminal.ansi.bright_black": "#414868",
+            "terminal.ansi.dim_black": null,
+            "terminal.ansi.red": "#f7768e",
+            "terminal.ansi.bright_red": "#f7768e",
+            "terminal.ansi.dim_red": null,
+            "terminal.ansi.green": "#73daca",
+            "terminal.ansi.bright_green": "#73daca",
+            "terminal.ansi.dim_green": null,
+            "terminal.ansi.yellow": "#e0af68",
+            "terminal.ansi.bright_yellow": "#e0af68",
+            "terminal.ansi.dim_yellow": null,
+            "terminal.ansi.blue": "#7aa2f7",
+            "terminal.ansi.bright_blue": "#7aa2f7",
+            "terminal.ansi.dim_blue": null,
+            "terminal.ansi.magenta": "#bb9af7",
+            "terminal.ansi.bright_magenta": "#bb9af7",
+            "terminal.ansi.dim_magenta": null,
+            "terminal.ansi.cyan": "#7dcfff",
+            "terminal.ansi.bright_cyan": "#7dcfff",
+            "terminal.ansi.dim_cyan": null,
+            "terminal.ansi.white": "#7982a9",
+            "terminal.ansi.bright_white": "#a9b1d6",
+            "terminal.ansi.dim_white": null,
+            "link_text.hover": "#7dcfff",
+            "conflict": "#bb9af7",
+            "conflict.background": "#24283b",
+            "conflict.border": "#414868",
+            "created": "#9ece6a",
+            "created.background": "#24283b",
+            "created.border": "#414868",
+            "deleted": "#f7768e",
+            "deleted.background": "#24283b",
+            "deleted.border": "#414868",
+            "error": "#f7768e",
+            "error.background": "#24283b",
+            "error.border": "#414868",
+            "hidden": "#787c99",
+            "hidden.background": "#24283b",
+            "hidden.border": "#414868",
+            "hint": "#5f6996",
+            "hint.background": "#24283b",
+            "hint.border": "#414868",
+            "ignored": "#515670",
+            "ignored.background": "#24283b",
+            "ignored.border": "#414868",
+            "info": "#0da0ba",
+            "info.background": "#24283b",
+            "info.border": "#414868",
+            "modified": "#e0af68",
+            "modified.background": "#24283b",
+            "modified.border": "#414868",
+            "predictive": "#5f6996",
+            "predictive.background": "#24283b",
+            "predictive.border": "#414868",
+            "renamed": "#9ece6a",
+            "renamed.background": "#24283b",
+            "renamed.border": "#414868",
+            "success": "#9ece6a",
+            "success.background": "#24283b",
+            "success.border": "#414868",
+            "unreachable": "#f7768e",
+            "unreachable.background": "#24283b",
+            "unreachable.border": "#414868",
+            "warning": "#e0af68",
+            "warning.background": "#24283b",
+            "warning.border": "#414868",
+            "players": [
+              {
+                "cursor": "#7c7f93",
+                "background": "#7c7f93",
+                "selection": "#7c7f93"
+              }
+            ],
+            "syntax": {
+              "attribute": {
+                "color": "#bb9af7",
+                "font_style": null,
+                "font_weight": null
+              },
+              "boolean": {
+                "color": "#ff9e64",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment": {
+                "color": "#5f6996",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment.doc": {
+                "color": "#5f6996",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constant": {
+                "color": "#ff9e64",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constructor": {
+                "color": "#f7768e",
+                "font_style": null,
+                "font_weight": null
+              },
+              "emphasis": {
+                "color": "#f7768e",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "emphasis.strong": {
+                "color": "#f7768e",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "function": {
+                "color": "#7aa2f7",
+                "font_style": null,
+                "font_weight": null
+              },
+              "keyword": {
+                "color": "#bb9af7",
+                "font_style": null,
+                "font_weight": null
+              },
+              "label": {
+                "color": "#c0caf5",
+                "font_style": null,
+                "font_weight": null
+              },
+              "link_text": {
+                "color": "#73daca",
+                "font_style": null,
+                "font_weight": null
+              },
+              "link_uri": {
+                "color": "#73daca",
+                "font_style": null,
+                "font_weight": null
+              },
+              "number": {
+                "color": "#ff9e64",
+                "font_style": null,
+                "font_weight": null
+              },
+              "operator": {
+                "color": "#89ddff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "preproc": {
+                "color": "#73daca",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation": {
+                "color": "#89ddff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.bracket": {
+                "color": "#89ddff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.delimiter": {
+                "color": "#89ddff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.list_marker": {
+                "color": "#89ddff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.special": {
+                "color": "#89ddff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string": {
+                "color": "#9ece6a",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.escape": {
+                "color": "#bb9af7",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.regex": {
+                "color": "#9ece6a",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special": {
+                "color": "#9ece6a",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special.symbol": {
+                "color": "#9ece6a",
+                "font_style": null,
+                "font_weight": null
+              },
+              "tag": {
+                "color": "#f7768e",
+                "font_style": null,
+                "font_weight": null
+              },
+              "text.literal": {
+                "color": "#9ece6a",
+                "font_style": null,
+                "font_weight": null
+              },
+              "title": {
+                "color": "#ff9e64",
+                "font_style": null,
+                "font_weight": null
+              },
+              "type": {
+                "color": "#2ac3de",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable": {
+                "color": "#c0caf5",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable.special": {
+                "color": "#f7768e",
+                "font_style": null,
+                "font_weight": null
+              }
+            }
+          }
+        }
+      ]
+    },
+    "userId": null,
+    "installCount": 49451
+  },
+  {
+    "id": "the-dark-side",
+    "name": "The Dark Side",
+    "author": "Sai Gokula Krishnan",
+    "updatedDate": 1712922439000,
+    "versionHash": "0.2.5",
+    "bundled": true,
+    "repoUrl": "https://github.com/Imgkl/the-dark-side",
+    "repoStars": 35,
+    "theme": {
+      "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
+      "name": "The Dark Side",
+      "author": "Sai Gokula Krishnan",
+      "themes": [
+        {
+          "name": "The Dark Side",
+          "appearance": "dark",
+          "style": {
+            "info.background": "#0C194D",
+            "info.border": "#0C194D",
+            "info.foreground": "#ffffff",
+            "warning.background": "#3A310E",
+            "warning.foreground": "#ffffff",
+            "warning.border": "#3A310E",
+            "error.background": "#4D0C0C",
+            "error.foreground": "#ffffff",
+            "error.border": "#4D0C0C",
+            "predictive": "#7f848e",
+            "predictive.background": "#E6E9EF",
+            "predictive.border": "#7f848e",
+            "background": "#000000",
+            "editor.background": "#000000",
+            "border": "#ffffff20",
+            "border.variant": "#000000",
+            "element.background": "#000000",
+            "element.active": "#ffffff20",
+            "element.hover": "#ffffff20",
+            "editor.active_line_number": "#FFFFFF",
+            "status_bar.background": "#000000",
+            "status_bar.foreground": "#ffffff",
+            "title_bar.background": "#000000",
+            "title_bar.foreground": "#ffffff",
+            "tab.active_background": "#000000",
+            "tab.active_foreground": "#ffffff",
+            "tab.inactive_background": "#ffffff20",
+            "tab_bar.background": "#000000",
+            "editor.gutter.background": "#000000",
+            "panel.background": "#000000",
+            "panel.focused_border": "#ffffff",
+            "toolbar.background": "#000000",
+            "terminal.background": "#000000",
+            "terminal.foreground": "#ffffff",
+            "terminal.ansi.red": "#d20f39",
+            "terminal.ansi.bright_red": "#d20f39",
+            "terminal.ansi.dim_red": null,
+            "terminal.ansi.bright_black": "#7f848e",
+            "terminal.bright_foreground": null,
+            "terminal.ansi.black": "#bcc0cc",
+            "terminal.ansi.dim_black": null,
+            "terminal.ansi.cyan": "#7287FD",
+            "terminal.ansi.bright_cyan": "#7287FD",
+            "terminal.ansi.dim_cyan": null,
+            "terminal.ansi.white": "#acb0be",
+            "terminal.ansi.bright_white": "#5c5f77",
+            "terminal.ansi.dim_white": null,
+            "terminal.ansi.yellow": "#e5c07b",
+            "terminal.ansi.bright_yellow": "#e5c07b",
+            "terminal.ansi.dim_yellow": null,
+            "terminal.ansi.green": "#40a02b",
+            "terminal.ansi.bright_green": "#40a02b",
+            "terminal.ansi.dim_green": null,
+            "terminal.ansi.blue": "#1e66f5",
+            "terminal.ansi.bright_blue": "#1e66f5",
+            "terminal.ansi.dim_blue": null,
+            "terminal.ansi.magenta": "#ea76cb",
+            "terminal.ansi.bright_magenta": "#ea76cb",
+            "terminal.ansi.dim_magenta": null,
+            "scrollbar_thumb.background": "#ffffff",
+            "scrollbar.thumb.hover_background": "#ffffff",
+            "scrollbar.thumb.border": "#000000",
+            "scrollbar.track.background": "#000000",
+            "scrollbar.track.border": "#000000",
+            "editor.active_line.background": "#ffffff25",
+            "editor.highlighted_line.background": "#000000",
+            "editor.line_number": "#ffffff30",
+            "elevated_surface.background": "#0D0E0E",
+            "elevated_surface.border": "#ffffff",
+            "surface.background": "#000000",
+            "modified": "#e5c07b",
+            "syntax": {
+              "exception": {
+                "color": "#DC143C",
+                "font_style": "italic"
+              },
+              "type.function": {
+                "color": "#9a77cf",
+                "font_style": "italic"
+              },
+              "function.method": {
+                "color": "#DC143C",
+                "font_style": "italic"
+              },
+              "comment": {
+                "color": "#7f848e",
+                "font_style": "italic"
+              },
+              "keyword": {
+                "color": "#7725EE",
+                "font_style": "italic"
+              },
+              "string": {
+                "color": "#e5c07b",
+                "font_style": "italic"
+              },
+              "keyword.conditional": {
+                "color": "#ff6700",
+                "font_style": "italic"
+              },
+              "keyword.coroutine": {
+                "color": "#ff6700",
+                "font_style": "italic"
+              },
+              "keyword.repeat": {
+                "color": "#ff6700",
+                "font_style": "italic"
+              },
+              "keyword.exception": {
+                "color": "#DC143C",
+                "font_style": "italic"
+              },
+              "keyword.operator": {
+                "color": "#ff6700",
+                "font_style": "italic"
+              },
+              "string.escape": {
+                "color": "#EA76CB",
+                "font_style": "italic"
+              },
+              "boolean": {
+                "color": "#e5c07b",
+                "font_style": "italic"
+              },
+              "constant": {
+                "color": "#DC143C",
+                "font_style": "italic"
+              },
+              "punctuation.special": {
+                "color": "#ff6700",
+                "font_style": "italic"
+              },
+              "number": {
+                "color": "#e5c07b",
+                "font_style": "italic"
+              },
+              "punctuation": {
+                "color": "#7755EE"
+              },
+              "variable": {
+                "color": "#df881d"
+              },
+              "operator": {
+                "color": "#7755EE"
+              },
+              "type": {
+                "color": "#9a77cf",
+                "font_style": "italic"
+              },
+              "variable.builtin": {
+                "color": "#ff6700",
+                "font_style": "italic"
+              },
+              "variable.parameter": {
+                "color": "#ff6700",
+                "font_style": "italic"
+              }
+            },
+            "players": [
+              {
+                "cursor": "#ffffff",
+                "selection": "#ffffff20"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "userId": null,
+    "installCount": 42983
+  },
+  {
+    "id": "github-theme",
+    "name": "Github",
+    "author": "Pyae Sone Aung, Clay Tercek",
+    "updatedDate": 1727105825000,
+    "versionHash": "0.1.1",
+    "bundled": true,
+    "repoUrl": "https://github.com/PyaeSoneAungRgn/github-zed-theme",
+    "repoStars": 49,
+    "theme": {
+      "$schema": "https://zed.dev/schema/themes/v0.1.0.json",
+      "name": "Github Theme",
+      "author": "Pyae Sone Aung",
+      "themes": [
+        {
+          "appearance": "light",
+          "name": "Github Light",
+          "style": {
+            "background": "#ffffffff",
+            "border": "#d1d9e0ff",
+            "border.disabled": "#818b981a",
+            "border.focused": "#0969daff",
+            "border.selected": "#0969daff",
+            "border.transparent": "#ffffff00",
+            "border.variant": "#d1d9e0b3",
+            "conflict": "#bc4c00ff",
+            "conflict.background": "#fff1e5ff",
+            "conflict.border": "#fb8f4466",
+            "created": "#1a7f37ff",
+            "created.background": "#dafbe1ff",
+            "created.border": "#4ac26b66",
+            "deleted": "#d1242fff",
+            "deleted.background": "#ffebe9ff",
+            "deleted.border": "#ff818266",
+            "drop_target.background": "#ddf4ffff",
+            "editor.active_line.background": "#f6f8faff",
+            "editor.active_line_number": "#1f2328ff",
+            "editor.active_wrap_guide": "#d1d9e0b3",
+            "editor.background": "#ffffffff",
+            "editor.document_highlight.read_background": "#0969da4d",
+            "editor.document_highlight.write_background": "#0969da33",
+            "editor.foreground": "#1f2328ff",
+            "editor.gutter.background": "#ffffffff",
+            "editor.highlighted_line.background": "#818b981f",
+            "editor.invisible": "#818b98ff",
+            "editor.line_number": "#59636eff",
+            "editor.subheader.background": "#f6f8faff",
+            "editor.wrap_guide": "#d1d9e0b3",
+            "element.active": "#818b981f",
+            "element.background": "#818b981f",
+            "element.disabled": "#eff2f5ff",
+            "element.hover": "#818b981f",
+            "element.selected": "#818b981f",
+            "elevated_surface.background": "#f6f8faff",
+            "error": "#d1242fff",
+            "error.background": "#f6f8faff",
+            "error.border": "#d1d9e0b3",
+            "ghost_element.active": "#818b981f",
+            "ghost_element.background": "#ffffff00",
+            "ghost_element.disabled": "#eff2f5ff",
+            "ghost_element.hover": "#ffffffff",
+            "ghost_element.selected": "#818b981f",
+            "hidden": "#818b98ff",
+            "hidden.background": "#eff2f5ff",
+            "hidden.border": "#818b981a",
+            "hint": "#59636eff",
+            "hint.background": "#f6f8faff",
+            "hint.border": "#d1d9e0b3",
+            "icon": "#1f2328ff",
+            "icon.background": "#ffffffff",
+            "icon.border": "#d1d9e0ff",
+            "icon.accent": "#0969daff",
+            "icon.muted": "#59636eff",
+            "icon.disabled": "#818b98ff",
+            "ignored": "#59636eff",
+            "ignored.background": "#eff2f5ff",
+            "ignored.border": "#818b981a",
+            "info": "#9a6700ff",
+            "info.background": "#f6f8faff",
+            "info.border": "#d1d9e0b3",
+            "link_text.hover": "#0969daff",
+            "modified": "#9a6700ff",
+            "modified.background": "#fff8c5ff",
+            "modified.border": "#d4a72c66",
+            "pane.focused_border": "#d1d9e0ff",
+            "panel.background": "#f6f8faff",
+            "panel.focused_border": "#d1d9e0ff",
+            "predictive.background": "#818b981f",
+            "predictive.border": "#d1d9e0b3",
+            "renamed": "#1a7f37ff",
+            "renamed.background": "#dafbe1ff",
+            "renamed.border": "#4ac26b66",
+            "scrollbar.thumb.border": "#ffffff00",
+            "scrollbar.thumb.hover_background": "#f6f8faff",
+            "scrollbar.track.background": "#ffffff00",
+            "scrollbar.track.border": "#ffffff00",
+            "search.match_background": "#fae17d4d",
+            "status_bar.background": "#f6f8faff",
+            "success": "#1a7f37ff",
+            "success.background": "#dafbe1ff",
+            "success.border": "#4ac26b66",
+            "surface.background": "#f6f8faff",
+            "tab.active_background": "#ffffffff",
+            "tab.inactive_background": "#f6f8faff",
+            "tab_bar.background": "#f6f8faff",
+            "terminal.ansi.black": "#1f2328ff",
+            "terminal.ansi.bright_black": "#393f46ff",
+            "terminal.ansi.dim_black": "#1f2328ff",
+            "terminal.ansi.blue": "#0969daff",
+            "terminal.ansi.bright_blue": "#218bffff",
+            "terminal.ansi.dim_blue": "#0969daff",
+            "terminal.ansi.cyan": "#1b7c83ff",
+            "terminal.ansi.bright_cyan": "#3192aaff",
+            "terminal.ansi.dim_cyan": "#1b7c83ff",
+            "terminal.ansi.green": "#116329ff",
+            "terminal.ansi.bright_green": "#1a7f37ff",
+            "terminal.ansi.dim_green": "#116329ff",
+            "terminal.ansi.magenta": "#8250dfff",
+            "terminal.ansi.bright_magenta": "#a475f9ff",
+            "terminal.ansi.dim_magenta": "#8250dfff",
+            "terminal.ansi.red": "#cf222eff",
+            "terminal.ansi.bright_red": "#a40e26ff",
+            "terminal.ansi.dim_red": "#cf222eff",
+            "terminal.ansi.white": "#59636eff",
+            "terminal.ansi.bright_white": "#818b98ff",
+            "terminal.ansi.dim_white": "#59636eff",
+            "terminal.ansi.yellow": "#4d2d00ff",
+            "terminal.ansi.bright_yellow": "#633c01ff",
+            "terminal.ansi.dim_yellow": "#4d2d00ff",
+            "terminal.background": "#f6f8faff",
+            "terminal.bright_foreground": "#ffffffff",
+            "terminal.dim_foreground": "#59636eff",
+            "terminal.foreground": "#1f2328ff",
+            "text": "#1f2328ff",
+            "text.accent": "#0969daff",
+            "text.disabled": "#818b98ff",
+            "text.muted": "#1f2328ff",
+            "title_bar.background": "#f6f8faff",
+            "toolbar.background": "#ffffffff",
+            "unreachable": "#818b98ff",
+            "unreachable.background": "#eff2f5ff",
+            "unreachable.border": "#818b981a",
+            "warning": "#9a6700ff",
+            "warning.background": "#f6f8faff",
+            "warning.border": "#d1d9e0b3",
+            "players": [
+              {
+                "cursor": "#006edbff",
+                "background": "#006edbff",
+                "selection": "#006edb66"
+              },
+              {
+                "cursor": "#eb670fff",
+                "background": "#eb670fff",
+                "selection": "#eb670f66"
+              },
+              {
+                "cursor": "#ce2c85ff",
+                "background": "#ce2c85ff",
+                "selection": "#ce2c8566"
+              },
+              {
+                "cursor": "#30a147ff",
+                "background": "#30a147ff",
+                "selection": "#30a14766"
+              },
+              {
+                "cursor": "#894cebff",
+                "background": "#894cebff",
+                "selection": "#894ceb66"
+              },
+              {
+                "cursor": "#b88700ff",
+                "background": "#b88700ff",
+                "selection": "#b8870066"
+              },
+              {
+                "cursor": "#179b9bff",
+                "background": "#179b9bff",
+                "selection": "#179b9b66"
+              },
+              {
+                "cursor": "#df0c24ff",
+                "background": "#df0c24ff",
+                "selection": "#df0c2466"
+              }
+            ],
+            "syntax": {
+              "attribute": {
+                "color": null,
+                "font_style": null,
+                "font_weight": null
+              },
+              "boolean": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment": {
+                "color": "#59636eff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment.doc": {
+                "color": "#59636eff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constant": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constructor": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "embedded": {
+                "color": "#cf222eff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "emphasis": {
+                "color": null,
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "emphasis.strong": {
+                "color": null,
+                "font_style": null,
+                "font_weight": 700
+              },
+              "enum": {
+                "color": "#953800ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function": {
+                "color": "#8250dfff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function.method": {
+                "color": "#8250dfff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function.special.definition": {
+                "color": "#8250dfff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "hint": {
+                "color": "#59636eff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "keyword": {
+                "color": "#cf222eff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "label": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "link_text": {
+                "color": "#0a3069ff",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "link_uri": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "number": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "operator": {
+                "color": "#1f2328ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "predictive": {
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "preproc": {
+                "color": "#cf222eff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "primary": {
+                "color": "#1f2328ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "property": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation": {
+                "color": "#1f2328ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.bracket": {
+                "color": "#1f2328ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.delimiter": {
+                "color": "#1f2328ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.list_marker": {
+                "color": "#953800ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.special": {
+                "color": "#cf222eff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string": {
+                "color": "#0a3069ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.escape": {
+                "color": "#116329ff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "string.regex": {
+                "color": "#0a3069ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special.symbol": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "tag": {
+                "color": "#116329ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "text.literal": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "title": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "type": {
+                "color": "#953800ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable": {
+                "color": "#1f2328ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable.special": {
+                "color": "#cf222eff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variant": {
+                "color": "#953800ff",
+                "font_style": null,
+                "font_weight": null
+              }
+            }
+          }
+        },
+        {
+          "appearance": "light",
+          "name": "Github Light Colorblind",
+          "style": {
+            "background": "#ffffffff",
+            "border": "#d1d9e0ff",
+            "border.disabled": "#818b981a",
+            "border.focused": "#0969daff",
+            "border.selected": "#0969daff",
+            "border.transparent": "#ffffff00",
+            "border.variant": "#d1d9e0b3",
+            "conflict": "#bc4c00ff",
+            "conflict.background": "#fff1e5ff",
+            "conflict.border": "#fb8f4466",
+            "created": "#0969daff",
+            "created.background": "#ddf4ffff",
+            "created.border": "#54aeff66",
+            "deleted": "#be4e02ff",
+            "deleted.background": "#fff1e5ff",
+            "deleted.border": "#fb8f4466",
+            "drop_target.background": "#ddf4ffff",
+            "editor.active_line.background": "#f6f8faff",
+            "editor.active_line_number": "#1f2328ff",
+            "editor.active_wrap_guide": "#d1d9e0b3",
+            "editor.background": "#ffffffff",
+            "editor.document_highlight.read_background": "#0969da4d",
+            "editor.document_highlight.write_background": "#0969da33",
+            "editor.foreground": "#1f2328ff",
+            "editor.gutter.background": "#ffffffff",
+            "editor.highlighted_line.background": "#818b981f",
+            "editor.invisible": "#818b98ff",
+            "editor.line_number": "#59636eff",
+            "editor.subheader.background": "#f6f8faff",
+            "editor.wrap_guide": "#d1d9e0b3",
+            "element.active": "#818b981f",
+            "element.background": "#818b981f",
+            "element.disabled": "#eff2f5ff",
+            "element.hover": "#818b981f",
+            "element.selected": "#818b981f",
+            "elevated_surface.background": "#f6f8faff",
+            "error": "#be4e02ff",
+            "error.background": "#f6f8faff",
+            "error.border": "#d1d9e0b3",
+            "ghost_element.active": "#818b981f",
+            "ghost_element.background": "#ffffff00",
+            "ghost_element.disabled": "#eff2f5ff",
+            "ghost_element.hover": "#ffffffff",
+            "ghost_element.selected": "#818b981f",
+            "hidden": "#818b98ff",
+            "hidden.background": "#eff2f5ff",
+            "hidden.border": "#818b981a",
+            "hint": "#59636eff",
+            "hint.background": "#f6f8faff",
+            "hint.border": "#d1d9e0b3",
+            "icon": "#1f2328ff",
+            "icon.background": "#ffffffff",
+            "icon.border": "#d1d9e0ff",
+            "icon.accent": "#0969daff",
+            "icon.muted": "#59636eff",
+            "icon.disabled": "#818b98ff",
+            "ignored": "#59636eff",
+            "ignored.background": "#eff2f5ff",
+            "ignored.border": "#818b981a",
+            "info": "#9a6700ff",
+            "info.background": "#f6f8faff",
+            "info.border": "#d1d9e0b3",
+            "link_text.hover": "#0969daff",
+            "modified": "#9a6700ff",
+            "modified.background": "#fff8c5ff",
+            "modified.border": "#d4a72c66",
+            "pane.focused_border": "#d1d9e0ff",
+            "panel.background": "#f6f8faff",
+            "panel.focused_border": "#d1d9e0ff",
+            "predictive.background": "#818b981f",
+            "predictive.border": "#d1d9e0b3",
+            "renamed": "#0969daff",
+            "renamed.background": "#ddf4ffff",
+            "renamed.border": "#54aeff66",
+            "scrollbar.thumb.border": "#ffffff00",
+            "scrollbar.thumb.hover_background": "#f6f8faff",
+            "scrollbar.track.background": "#ffffff00",
+            "scrollbar.track.border": "#ffffff00",
+            "search.match_background": "#fae17d4d",
+            "status_bar.background": "#f6f8faff",
+            "success": "#0969daff",
+            "success.background": "#ddf4ffff",
+            "success.border": "#54aeff66",
+            "surface.background": "#f6f8faff",
+            "tab.active_background": "#ffffffff",
+            "tab.inactive_background": "#f6f8faff",
+            "tab_bar.background": "#f6f8faff",
+            "terminal.ansi.black": "#1f2328ff",
+            "terminal.ansi.bright_black": "#393f46ff",
+            "terminal.ansi.dim_black": "#1f2328ff",
+            "terminal.ansi.blue": "#0969daff",
+            "terminal.ansi.bright_blue": "#218bffff",
+            "terminal.ansi.dim_blue": "#0969daff",
+            "terminal.ansi.cyan": "#1b7c83ff",
+            "terminal.ansi.bright_cyan": "#3192aaff",
+            "terminal.ansi.dim_cyan": "#1b7c83ff",
+            "terminal.ansi.green": "#0550aeff",
+            "terminal.ansi.bright_green": "#0969daff",
+            "terminal.ansi.dim_green": "#0550aeff",
+            "terminal.ansi.magenta": "#8250dfff",
+            "terminal.ansi.bright_magenta": "#a475f9ff",
+            "terminal.ansi.dim_magenta": "#8250dfff",
+            "terminal.ansi.red": "#bc4c00ff",
+            "terminal.ansi.bright_red": "#953800ff",
+            "terminal.ansi.dim_red": "#bc4c00ff",
+            "terminal.ansi.white": "#59636eff",
+            "terminal.ansi.bright_white": "#818b98ff",
+            "terminal.ansi.dim_white": "#59636eff",
+            "terminal.ansi.yellow": "#4d2d00ff",
+            "terminal.ansi.bright_yellow": "#633c01ff",
+            "terminal.ansi.dim_yellow": "#4d2d00ff",
+            "terminal.background": "#f6f8faff",
+            "terminal.bright_foreground": "#ffffffff",
+            "terminal.dim_foreground": "#59636eff",
+            "terminal.foreground": "#1f2328ff",
+            "text": "#1f2328ff",
+            "text.accent": "#0969daff",
+            "text.disabled": "#818b98ff",
+            "text.muted": "#1f2328ff",
+            "title_bar.background": "#f6f8faff",
+            "toolbar.background": "#ffffffff",
+            "unreachable": "#818b98ff",
+            "unreachable.background": "#eff2f5ff",
+            "unreachable.border": "#818b981a",
+            "warning": "#9a6700ff",
+            "warning.background": "#f6f8faff",
+            "warning.border": "#d1d9e0b3",
+            "players": [
+              {
+                "cursor": "#006edbff",
+                "background": "#006edbff",
+                "selection": "#006edb66"
+              },
+              {
+                "cursor": "#eb670fff",
+                "background": "#eb670fff",
+                "selection": "#eb670f66"
+              },
+              {
+                "cursor": "#ce2c85ff",
+                "background": "#ce2c85ff",
+                "selection": "#ce2c8566"
+              },
+              {
+                "cursor": "#30a147ff",
+                "background": "#30a147ff",
+                "selection": "#30a14766"
+              },
+              {
+                "cursor": "#894cebff",
+                "background": "#894cebff",
+                "selection": "#894ceb66"
+              },
+              {
+                "cursor": "#b88700ff",
+                "background": "#b88700ff",
+                "selection": "#b8870066"
+              },
+              {
+                "cursor": "#179b9bff",
+                "background": "#179b9bff",
+                "selection": "#179b9b66"
+              },
+              {
+                "cursor": "#df0c24ff",
+                "background": "#df0c24ff",
+                "selection": "#df0c2466"
+              }
+            ],
+            "syntax": {
+              "attribute": {
+                "color": null,
+                "font_style": null,
+                "font_weight": null
+              },
+              "boolean": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment": {
+                "color": "#59636eff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment.doc": {
+                "color": "#59636eff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constant": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constructor": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "embedded": {
+                "color": "#cf222eff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "emphasis": {
+                "color": null,
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "emphasis.strong": {
+                "color": null,
+                "font_style": null,
+                "font_weight": 700
+              },
+              "enum": {
+                "color": "#953800ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function": {
+                "color": "#8250dfff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function.method": {
+                "color": "#8250dfff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function.special.definition": {
+                "color": "#8250dfff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "hint": {
+                "color": "#59636eff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "keyword": {
+                "color": "#cf222eff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "label": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "link_text": {
+                "color": "#0a3069ff",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "link_uri": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "number": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "operator": {
+                "color": "#1f2328ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "predictive": {
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "preproc": {
+                "color": "#cf222eff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "primary": {
+                "color": "#1f2328ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "property": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation": {
+                "color": "#1f2328ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.bracket": {
+                "color": "#1f2328ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.delimiter": {
+                "color": "#1f2328ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.list_marker": {
+                "color": "#953800ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.special": {
+                "color": "#cf222eff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string": {
+                "color": "#0a3069ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.escape": {
+                "color": "#116329ff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "string.regex": {
+                "color": "#0a3069ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special.symbol": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "tag": {
+                "color": "#116329ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "text.literal": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "title": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "type": {
+                "color": "#953800ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable": {
+                "color": "#1f2328ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable.special": {
+                "color": "#cf222eff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variant": {
+                "color": "#953800ff",
+                "font_style": null,
+                "font_weight": null
+              }
+            }
+          }
+        },
+        {
+          "appearance": "light",
+          "name": "Github Light High Contrast",
+          "style": {
+            "background": "#ffffffff",
+            "border": "#454c54ff",
+            "border.disabled": "#59636e1f",
+            "border.focused": "#0349b4ff",
+            "border.selected": "#0349b4ff",
+            "border.transparent": "#ffffff00",
+            "border.variant": "#454c54ff",
+            "conflict": "#702c00ff",
+            "conflict.background": "#fff2d5ff",
+            "conflict.border": "#dc6d1aff",
+            "created": "#024c1aff",
+            "created.background": "#d2fedbff",
+            "created.border": "#26a148ff",
+            "deleted": "#8a071eff",
+            "deleted.background": "#fff0eeff",
+            "deleted.border": "#ee5a5dff",
+            "drop_target.background": "#dff7ffff",
+            "editor.active_line.background": "#e6eaefff",
+            "editor.active_line_number": "#010409ff",
+            "editor.active_wrap_guide": "#454c54ff",
+            "editor.background": "#ffffffff",
+            "editor.document_highlight.read_background": "#023b954d",
+            "editor.document_highlight.write_background": "#023b9533",
+            "editor.foreground": "#010409ff",
+            "editor.gutter.background": "#ffffffff",
+            "editor.highlighted_line.background": "#e0e6ebff",
+            "editor.invisible": "#59636eff",
+            "editor.line_number": "#454c54ff",
+            "editor.subheader.background": "#e6eaefff",
+            "editor.wrap_guide": "#454c54ff",
+            "element.active": "#e0e6ebff",
+            "element.background": "#e0e6ebff",
+            "element.disabled": "#e0e6ebff",
+            "element.hover": "#e0e6ebff",
+            "element.selected": "#e0e6ebff",
+            "elevated_surface.background": "#e6eaefff",
+            "error": "#8a071eff",
+            "error.background": "#e6eaefff",
+            "error.border": "#454c54ff",
+            "ghost_element.active": "#e0e6ebff",
+            "ghost_element.background": "#ffffff00",
+            "ghost_element.disabled": "#e0e6ebff",
+            "ghost_element.hover": "#ffffffff",
+            "ghost_element.selected": "#e0e6ebff",
+            "hidden": "#59636eff",
+            "hidden.background": "#e0e6ebff",
+            "hidden.border": "#59636e1f",
+            "hint": "#454c54ff",
+            "hint.background": "#e6eaefff",
+            "hint.border": "#454c54ff",
+            "icon": "#010409ff",
+            "icon.background": "#ffffffff",
+            "icon.border": "#454c54ff",
+            "icon.accent": "#023b95ff",
+            "icon.muted": "#454c54ff",
+            "icon.disabled": "#59636eff",
+            "ignored": "#454c54ff",
+            "ignored.background": "#e0e6ebff",
+            "ignored.border": "#59636e1f",
+            "info": "#603700ff",
+            "info.background": "#e6eaefff",
+            "info.border": "#454c54ff",
+            "link_text.hover": "#023b95ff",
+            "modified": "#603700ff",
+            "modified.background": "#fcf7beff",
+            "modified.border": "#b58407ff",
+            "pane.focused_border": "#454c54ff",
+            "panel.background": "#eff2f5ff",
+            "panel.focused_border": "#454c54ff",
+            "predictive.background": "#e0e6ebff",
+            "predictive.border": "#454c54ff",
+            "renamed": "#024c1aff",
+            "renamed.background": "#d2fedbff",
+            "renamed.border": "#26a148ff",
+            "scrollbar.thumb.border": "#ffffff00",
+            "scrollbar.thumb.hover_background": "#e6eaefff",
+            "scrollbar.track.background": "#ffffff00",
+            "scrollbar.track.border": "#ffffff00",
+            "search.match_background": "#f0ce534d",
+            "status_bar.background": "#eff2f5ff",
+            "success": "#024c1aff",
+            "success.background": "#d2fedbff",
+            "success.border": "#26a148ff",
+            "surface.background": "#eff2f5ff",
+            "tab.active_background": "#ffffffff",
+            "tab.inactive_background": "#eff2f5ff",
+            "tab_bar.background": "#eff2f5ff",
+            "terminal.ansi.black": "#010409ff",
+            "terminal.ansi.bright_black": "#393f46ff",
+            "terminal.ansi.dim_black": "#010409ff",
+            "terminal.ansi.blue": "#0349b4ff",
+            "terminal.ansi.bright_blue": "#1168e3ff",
+            "terminal.ansi.dim_blue": "#0349b4ff",
+            "terminal.ansi.cyan": "#1b7c83ff",
+            "terminal.ansi.bright_cyan": "#3192aaff",
+            "terminal.ansi.dim_cyan": "#1b7c83ff",
+            "terminal.ansi.green": "#024c1aff",
+            "terminal.ansi.bright_green": "#055d20ff",
+            "terminal.ansi.dim_green": "#024c1aff",
+            "terminal.ansi.magenta": "#622cbcff",
+            "terminal.ansi.bright_magenta": "#844ae7ff",
+            "terminal.ansi.dim_magenta": "#622cbcff",
+            "terminal.ansi.red": "#a0111fff",
+            "terminal.ansi.bright_red": "#86061dff",
+            "terminal.ansi.dim_red": "#a0111fff",
+            "terminal.ansi.white": "#59636eff",
+            "terminal.ansi.bright_white": "#818b98ff",
+            "terminal.ansi.dim_white": "#59636eff",
+            "terminal.ansi.yellow": "#3f2200ff",
+            "terminal.ansi.bright_yellow": "#4e2c00ff",
+            "terminal.ansi.dim_yellow": "#3f2200ff",
+            "terminal.background": "#eff2f5ff",
+            "terminal.bright_foreground": "#ffffffff",
+            "terminal.dim_foreground": "#454c54ff",
+            "terminal.foreground": "#010409ff",
+            "text": "#010409ff",
+            "text.accent": "#023b95ff",
+            "text.disabled": "#59636eff",
+            "text.muted": "#010409ff",
+            "title_bar.background": "#eff2f5ff",
+            "toolbar.background": "#ffffffff",
+            "unreachable": "#59636eff",
+            "unreachable.background": "#e0e6ebff",
+            "unreachable.border": "#59636e1f",
+            "warning": "#603700ff",
+            "warning.background": "#e6eaefff",
+            "warning.border": "#454c54ff",
+            "players": [
+              {
+                "cursor": "#006edbff",
+                "background": "#006edbff",
+                "selection": "#006edb66"
+              },
+              {
+                "cursor": "#eb670fff",
+                "background": "#eb670fff",
+                "selection": "#eb670f66"
+              },
+              {
+                "cursor": "#ce2c85ff",
+                "background": "#ce2c85ff",
+                "selection": "#ce2c8566"
+              },
+              {
+                "cursor": "#30a147ff",
+                "background": "#30a147ff",
+                "selection": "#30a14766"
+              },
+              {
+                "cursor": "#894cebff",
+                "background": "#894cebff",
+                "selection": "#894ceb66"
+              },
+              {
+                "cursor": "#b88700ff",
+                "background": "#b88700ff",
+                "selection": "#b8870066"
+              },
+              {
+                "cursor": "#179b9bff",
+                "background": "#179b9bff",
+                "selection": "#179b9b66"
+              },
+              {
+                "cursor": "#df0c24ff",
+                "background": "#df0c24ff",
+                "selection": "#df0c2466"
+              }
+            ],
+            "syntax": {
+              "attribute": {
+                "color": null,
+                "font_style": null,
+                "font_weight": null
+              },
+              "boolean": {
+                "color": "#023b95ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment": {
+                "color": "#59636eff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment.doc": {
+                "color": "#59636eff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constant": {
+                "color": "#023b95ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constructor": {
+                "color": "#023b95ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "embedded": {
+                "color": "#a0111fff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "emphasis": {
+                "color": null,
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "emphasis.strong": {
+                "color": null,
+                "font_style": null,
+                "font_weight": 700
+              },
+              "enum": {
+                "color": "#702c00ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function": {
+                "color": "#622cbcff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function.method": {
+                "color": "#622cbcff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function.special.definition": {
+                "color": "#622cbcff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "hint": {
+                "color": "#454c54ff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "keyword": {
+                "color": "#a0111fff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "label": {
+                "color": "#023b95ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "link_text": {
+                "color": "#032563ff",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "link_uri": {
+                "color": "#023b95ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "number": {
+                "color": "#023b95ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "operator": {
+                "color": "#010409ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "predictive": {
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "preproc": {
+                "color": "#a0111fff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "primary": {
+                "color": "#010409ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "property": {
+                "color": "#023b95ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation": {
+                "color": "#010409ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.bracket": {
+                "color": "#010409ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.delimiter": {
+                "color": "#010409ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.list_marker": {
+                "color": "#702c00ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.special": {
+                "color": "#a0111fff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string": {
+                "color": "#032563ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.escape": {
+                "color": "#024c1aff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "string.regex": {
+                "color": "#032563ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special": {
+                "color": "#023b95ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special.symbol": {
+                "color": "#023b95ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "tag": {
+                "color": "#024c1aff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "text.literal": {
+                "color": "#023b95ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "title": {
+                "color": "#023b95ff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "type": {
+                "color": "#702c00ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable": {
+                "color": "#010409ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable.special": {
+                "color": "#a0111fff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variant": {
+                "color": "#702c00ff",
+                "font_style": null,
+                "font_weight": null
+              }
+            }
+          }
+        },
+        {
+          "appearance": "light",
+          "name": "Github Light Tritanopia",
+          "style": {
+            "background": "#ffffffff",
+            "border": "#d1d9e0ff",
+            "border.disabled": "#818b981a",
+            "border.focused": "#0969daff",
+            "border.selected": "#0969daff",
+            "border.transparent": "#ffffff00",
+            "border.variant": "#d1d9e0b3",
+            "conflict": "#cf222eff",
+            "conflict.background": "#ffebe9ff",
+            "conflict.border": "#ff818266",
+            "created": "#0969daff",
+            "created.background": "#ddf4ffff",
+            "created.border": "#54aeff66",
+            "deleted": "#d1242fff",
+            "deleted.background": "#ffebe9ff",
+            "deleted.border": "#ff818266",
+            "drop_target.background": "#ddf4ffff",
+            "editor.active_line.background": "#f6f8faff",
+            "editor.active_line_number": "#1f2328ff",
+            "editor.active_wrap_guide": "#d1d9e0b3",
+            "editor.background": "#ffffffff",
+            "editor.document_highlight.read_background": "#0969da4d",
+            "editor.document_highlight.write_background": "#0969da33",
+            "editor.foreground": "#1f2328ff",
+            "editor.gutter.background": "#ffffffff",
+            "editor.highlighted_line.background": "#818b981f",
+            "editor.invisible": "#818b98ff",
+            "editor.line_number": "#59636eff",
+            "editor.subheader.background": "#f6f8faff",
+            "editor.wrap_guide": "#d1d9e0b3",
+            "element.active": "#818b981f",
+            "element.background": "#818b981f",
+            "element.disabled": "#eff2f5ff",
+            "element.hover": "#818b981f",
+            "element.selected": "#818b981f",
+            "elevated_surface.background": "#f6f8faff",
+            "error": "#d1242fff",
+            "error.background": "#f6f8faff",
+            "error.border": "#d1d9e0b3",
+            "ghost_element.active": "#818b981f",
+            "ghost_element.background": "#ffffff00",
+            "ghost_element.disabled": "#eff2f5ff",
+            "ghost_element.hover": "#ffffffff",
+            "ghost_element.selected": "#818b981f",
+            "hidden": "#818b98ff",
+            "hidden.background": "#eff2f5ff",
+            "hidden.border": "#818b981a",
+            "hint": "#59636eff",
+            "hint.background": "#f6f8faff",
+            "hint.border": "#d1d9e0b3",
+            "icon": "#1f2328ff",
+            "icon.background": "#ffffffff",
+            "icon.border": "#d1d9e0ff",
+            "icon.accent": "#0969daff",
+            "icon.muted": "#59636eff",
+            "icon.disabled": "#818b98ff",
+            "ignored": "#59636eff",
+            "ignored.background": "#eff2f5ff",
+            "ignored.border": "#818b981a",
+            "info": "#9a6700ff",
+            "info.background": "#f6f8faff",
+            "info.border": "#d1d9e0b3",
+            "link_text.hover": "#0969daff",
+            "modified": "#9a6700ff",
+            "modified.background": "#fff8c5ff",
+            "modified.border": "#d4a72c66",
+            "pane.focused_border": "#d1d9e0ff",
+            "panel.background": "#f6f8faff",
+            "panel.focused_border": "#d1d9e0ff",
+            "predictive.background": "#818b981f",
+            "predictive.border": "#d1d9e0b3",
+            "renamed": "#0969daff",
+            "renamed.background": "#ddf4ffff",
+            "renamed.border": "#54aeff66",
+            "scrollbar.thumb.border": "#ffffff00",
+            "scrollbar.thumb.hover_background": "#f6f8faff",
+            "scrollbar.track.background": "#ffffff00",
+            "scrollbar.track.border": "#ffffff00",
+            "search.match_background": "#fae17d4d",
+            "status_bar.background": "#f6f8faff",
+            "success": "#0969daff",
+            "success.background": "#ddf4ffff",
+            "success.border": "#54aeff66",
+            "surface.background": "#f6f8faff",
+            "tab.active_background": "#ffffffff",
+            "tab.inactive_background": "#f6f8faff",
+            "tab_bar.background": "#f6f8faff",
+            "terminal.ansi.black": "#1f2328ff",
+            "terminal.ansi.bright_black": "#393f46ff",
+            "terminal.ansi.dim_black": "#1f2328ff",
+            "terminal.ansi.blue": "#0969daff",
+            "terminal.ansi.bright_blue": "#218bffff",
+            "terminal.ansi.dim_blue": "#0969daff",
+            "terminal.ansi.cyan": "#1b7c83ff",
+            "terminal.ansi.bright_cyan": "#3192aaff",
+            "terminal.ansi.dim_cyan": "#1b7c83ff",
+            "terminal.ansi.green": "#0550aeff",
+            "terminal.ansi.bright_green": "#0969daff",
+            "terminal.ansi.dim_green": "#0550aeff",
+            "terminal.ansi.magenta": "#8250dfff",
+            "terminal.ansi.bright_magenta": "#a475f9ff",
+            "terminal.ansi.dim_magenta": "#8250dfff",
+            "terminal.ansi.red": "#cf222eff",
+            "terminal.ansi.bright_red": "#a40e26ff",
+            "terminal.ansi.dim_red": "#cf222eff",
+            "terminal.ansi.white": "#59636eff",
+            "terminal.ansi.bright_white": "#818b98ff",
+            "terminal.ansi.dim_white": "#59636eff",
+            "terminal.ansi.yellow": "#4d2d00ff",
+            "terminal.ansi.bright_yellow": "#633c01ff",
+            "terminal.ansi.dim_yellow": "#4d2d00ff",
+            "terminal.background": "#f6f8faff",
+            "terminal.bright_foreground": "#ffffffff",
+            "terminal.dim_foreground": "#59636eff",
+            "terminal.foreground": "#1f2328ff",
+            "text": "#1f2328ff",
+            "text.accent": "#0969daff",
+            "text.disabled": "#818b98ff",
+            "text.muted": "#1f2328ff",
+            "title_bar.background": "#f6f8faff",
+            "toolbar.background": "#ffffffff",
+            "unreachable": "#818b98ff",
+            "unreachable.background": "#eff2f5ff",
+            "unreachable.border": "#818b981a",
+            "warning": "#9a6700ff",
+            "warning.background": "#f6f8faff",
+            "warning.border": "#d1d9e0b3",
+            "players": [
+              {
+                "cursor": "#006edbff",
+                "background": "#006edbff",
+                "selection": "#006edb66"
+              },
+              {
+                "cursor": "#eb670fff",
+                "background": "#eb670fff",
+                "selection": "#eb670f66"
+              },
+              {
+                "cursor": "#ce2c85ff",
+                "background": "#ce2c85ff",
+                "selection": "#ce2c8566"
+              },
+              {
+                "cursor": "#30a147ff",
+                "background": "#30a147ff",
+                "selection": "#30a14766"
+              },
+              {
+                "cursor": "#894cebff",
+                "background": "#894cebff",
+                "selection": "#894ceb66"
+              },
+              {
+                "cursor": "#b88700ff",
+                "background": "#b88700ff",
+                "selection": "#b8870066"
+              },
+              {
+                "cursor": "#179b9bff",
+                "background": "#179b9bff",
+                "selection": "#179b9b66"
+              },
+              {
+                "cursor": "#df0c24ff",
+                "background": "#df0c24ff",
+                "selection": "#df0c2466"
+              }
+            ],
+            "syntax": {
+              "attribute": {
+                "color": null,
+                "font_style": null,
+                "font_weight": null
+              },
+              "boolean": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment": {
+                "color": "#59636eff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment.doc": {
+                "color": "#59636eff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constant": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constructor": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "embedded": {
+                "color": "#cf222eff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "emphasis": {
+                "color": null,
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "emphasis.strong": {
+                "color": null,
+                "font_style": null,
+                "font_weight": 700
+              },
+              "enum": {
+                "color": "#953800ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function": {
+                "color": "#8250dfff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function.method": {
+                "color": "#8250dfff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function.special.definition": {
+                "color": "#8250dfff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "hint": {
+                "color": "#59636eff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "keyword": {
+                "color": "#cf222eff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "label": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "link_text": {
+                "color": "#0a3069ff",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "link_uri": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "number": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "operator": {
+                "color": "#1f2328ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "predictive": {
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "preproc": {
+                "color": "#cf222eff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "primary": {
+                "color": "#1f2328ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "property": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation": {
+                "color": "#1f2328ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.bracket": {
+                "color": "#1f2328ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.delimiter": {
+                "color": "#1f2328ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.list_marker": {
+                "color": "#953800ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.special": {
+                "color": "#cf222eff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string": {
+                "color": "#0a3069ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.escape": {
+                "color": "#116329ff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "string.regex": {
+                "color": "#0a3069ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special.symbol": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "tag": {
+                "color": "#116329ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "text.literal": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "title": {
+                "color": "#0550aeff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "type": {
+                "color": "#953800ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable": {
+                "color": "#1f2328ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable.special": {
+                "color": "#cf222eff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variant": {
+                "color": "#953800ff",
+                "font_style": null,
+                "font_weight": null
+              }
+            }
+          }
+        },
+        {
+          "appearance": "dark",
+          "name": "Github Dark",
+          "style": {
+            "background": "#0d1117ff",
+            "border": "#3d444dff",
+            "border.disabled": "#656c761a",
+            "border.focused": "#1f6febff",
+            "border.selected": "#1f6febff",
+            "border.transparent": "#00000000",
+            "border.variant": "#3d444db3",
+            "conflict": "#db6d28ff",
+            "conflict.background": "#db6d281a",
+            "conflict.border": "#db6d2866",
+            "created": "#3fb950ff",
+            "created.background": "#2ea04326",
+            "created.border": "#2ea04366",
+            "deleted": "#f85149ff",
+            "deleted.background": "#f851491a",
+            "deleted.border": "#f8514966",
+            "drop_target.background": "#388bfd1a",
+            "editor.active_line.background": "#151b23ff",
+            "editor.active_line_number": "#f0f6fcff",
+            "editor.active_wrap_guide": "#3d444db3",
+            "editor.background": "#0d1117ff",
+            "editor.document_highlight.read_background": "#4493f84d",
+            "editor.document_highlight.write_background": "#4493f833",
+            "editor.foreground": "#f0f6fcff",
+            "editor.gutter.background": "#0d1117ff",
+            "editor.highlighted_line.background": "#656c7633",
+            "editor.invisible": "#656c7699",
+            "editor.line_number": "#9198a1ff",
+            "editor.subheader.background": "#151b23ff",
+            "editor.wrap_guide": "#3d444db3",
+            "element.active": "#656c7633",
+            "element.background": "#656c7633",
+            "element.disabled": "#212830ff",
+            "element.hover": "#656c7633",
+            "element.selected": "#656c7633",
+            "elevated_surface.background": "#151b23ff",
+            "error": "#f85149ff",
+            "error.background": "#151b23ff",
+            "error.border": "#3d444db3",
+            "ghost_element.active": "#656c7633",
+            "ghost_element.background": "#00000000",
+            "ghost_element.disabled": "#212830ff",
+            "ghost_element.hover": "#0d1117ff",
+            "ghost_element.selected": "#656c7633",
+            "hidden": "#656c7699",
+            "hidden.background": "#212830ff",
+            "hidden.border": "#656c761a",
+            "hint": "#9198a1ff",
+            "hint.background": "#151b23ff",
+            "hint.border": "#3d444db3",
+            "icon": "#f0f6fcff",
+            "icon.background": "#0d1117ff",
+            "icon.border": "#3d444dff",
+            "icon.accent": "#4493f8ff",
+            "icon.muted": "#9198a1ff",
+            "icon.disabled": "#656c7699",
+            "ignored": "#9198a1ff",
+            "ignored.background": "#212830ff",
+            "ignored.border": "#656c761a",
+            "info": "#d29922ff",
+            "info.background": "#151b23ff",
+            "info.border": "#3d444db3",
+            "link_text.hover": "#4493f8ff",
+            "modified": "#d29922ff",
+            "modified.background": "#bb800926",
+            "modified.border": "#bb800966",
+            "pane.focused_border": "#3d444dff",
+            "panel.background": "#010409ff",
+            "panel.focused_border": "#3d444dff",
+            "predictive.background": "#656c7633",
+            "predictive.border": "#3d444db3",
+            "renamed": "#3fb950ff",
+            "renamed.background": "#2ea04326",
+            "renamed.border": "#2ea04366",
+            "scrollbar.thumb.border": "#00000000",
+            "scrollbar.thumb.hover_background": "#151b23ff",
+            "scrollbar.track.background": "#00000000",
+            "scrollbar.track.border": "#00000000",
+            "search.match_background": "#f2cc604d",
+            "status_bar.background": "#010409ff",
+            "success": "#3fb950ff",
+            "success.background": "#2ea04326",
+            "success.border": "#2ea04366",
+            "surface.background": "#010409ff",
+            "tab.active_background": "#0d1117ff",
+            "tab.inactive_background": "#010409ff",
+            "tab_bar.background": "#010409ff",
+            "terminal.ansi.black": "#2f3742ff",
+            "terminal.ansi.bright_black": "#656c76ff",
+            "terminal.ansi.dim_black": "#2f3742ff",
+            "terminal.ansi.blue": "#58a6ffff",
+            "terminal.ansi.bright_blue": "#79c0ffff",
+            "terminal.ansi.dim_blue": "#58a6ffff",
+            "terminal.ansi.cyan": "#39c5cfff",
+            "terminal.ansi.bright_cyan": "#56d4ddff",
+            "terminal.ansi.dim_cyan": "#39c5cfff",
+            "terminal.ansi.green": "#3fb950ff",
+            "terminal.ansi.bright_green": "#56d364ff",
+            "terminal.ansi.dim_green": "#3fb950ff",
+            "terminal.ansi.magenta": "#be8fffff",
+            "terminal.ansi.bright_magenta": "#d2a8ffff",
+            "terminal.ansi.dim_magenta": "#be8fffff",
+            "terminal.ansi.red": "#ff7b72ff",
+            "terminal.ansi.bright_red": "#ffa198ff",
+            "terminal.ansi.dim_red": "#ff7b72ff",
+            "terminal.ansi.white": "#f0f6fcff",
+            "terminal.ansi.bright_white": "#ffffffff",
+            "terminal.ansi.dim_white": "#f0f6fcff",
+            "terminal.ansi.yellow": "#d29922ff",
+            "terminal.ansi.bright_yellow": "#e3b341ff",
+            "terminal.ansi.dim_yellow": "#d29922ff",
+            "terminal.background": "#010409ff",
+            "terminal.bright_foreground": "#ffffffff",
+            "terminal.dim_foreground": "#9198a1ff",
+            "terminal.foreground": "#f0f6fcff",
+            "text": "#f0f6fcff",
+            "text.accent": "#4493f8ff",
+            "text.disabled": "#656c7699",
+            "text.muted": "#f0f6fcff",
+            "title_bar.background": "#010409ff",
+            "toolbar.background": "#0d1117ff",
+            "unreachable": "#656c7699",
+            "unreachable.background": "#212830ff",
+            "unreachable.border": "#656c761a",
+            "warning": "#d29922ff",
+            "warning.background": "#151b23ff",
+            "warning.border": "#3d444db3",
+            "players": [
+              {
+                "cursor": "#0576ffff",
+                "background": "#0576ffff",
+                "selection": "#0576ff66"
+              },
+              {
+                "cursor": "#984b10ff",
+                "background": "#984b10ff",
+                "selection": "#984b1066"
+              },
+              {
+                "cursor": "#d34591ff",
+                "background": "#d34591ff",
+                "selection": "#d3459166"
+              },
+              {
+                "cursor": "#2f6f37ff",
+                "background": "#2f6f37ff",
+                "selection": "#2f6f3766"
+              },
+              {
+                "cursor": "#975bf1ff",
+                "background": "#975bf1ff",
+                "selection": "#975bf166"
+              },
+              {
+                "cursor": "#895906ff",
+                "background": "#895906ff",
+                "selection": "#89590666"
+              },
+              {
+                "cursor": "#106c70ff",
+                "background": "#106c70ff",
+                "selection": "#106c7066"
+              },
+              {
+                "cursor": "#eb3342ff",
+                "background": "#eb3342ff",
+                "selection": "#eb334266"
+              }
+            ],
+            "syntax": {
+              "attribute": {
+                "color": null,
+                "font_style": null,
+                "font_weight": null
+              },
+              "boolean": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment": {
+                "color": "#9198a1ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment.doc": {
+                "color": "#9198a1ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constant": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constructor": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "embedded": {
+                "color": "#ff7b72ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "emphasis": {
+                "color": null,
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "emphasis.strong": {
+                "color": null,
+                "font_style": null,
+                "font_weight": 700
+              },
+              "enum": {
+                "color": "#ffa657ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function": {
+                "color": "#d2a8ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function.method": {
+                "color": "#d2a8ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function.special.definition": {
+                "color": "#d2a8ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "hint": {
+                "color": "#9198a1ff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "keyword": {
+                "color": "#ff7b72ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "label": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "link_text": {
+                "color": "#a5d6ffff",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "link_uri": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "number": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "operator": {
+                "color": "#f0f6fcff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "predictive": {
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "preproc": {
+                "color": "#ff7b72ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "primary": {
+                "color": "#f0f6fcff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "property": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation": {
+                "color": "#f0f6fcff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.bracket": {
+                "color": "#f0f6fcff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.delimiter": {
+                "color": "#f0f6fcff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.list_marker": {
+                "color": "#ffa657ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.special": {
+                "color": "#ff7b72ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string": {
+                "color": "#a5d6ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.escape": {
+                "color": "#7ee787ff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "string.regex": {
+                "color": "#a5d6ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special.symbol": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "tag": {
+                "color": "#7ee787ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "text.literal": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "title": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "type": {
+                "color": "#ffa657ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable": {
+                "color": "#f0f6fcff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable.special": {
+                "color": "#ff7b72ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variant": {
+                "color": "#ffa657ff",
+                "font_style": null,
+                "font_weight": null
+              }
+            }
+          }
+        },
+        {
+          "appearance": "dark",
+          "name": "Github Dark Colorblind",
+          "style": {
+            "background": "#0d1117ff",
+            "border": "#3d444dff",
+            "border.disabled": "#656c761a",
+            "border.focused": "#1f6febff",
+            "border.selected": "#1f6febff",
+            "border.transparent": "#00000000",
+            "border.variant": "#3d444db3",
+            "conflict": "#db6d28ff",
+            "conflict.background": "#db6d281a",
+            "conflict.border": "#db6d2866",
+            "created": "#58a6ffff",
+            "created.background": "#388bfd26",
+            "created.border": "#388bfd66",
+            "deleted": "#db6d28ff",
+            "deleted.background": "#db6d281a",
+            "deleted.border": "#db6d2866",
+            "drop_target.background": "#388bfd1a",
+            "editor.active_line.background": "#151b23ff",
+            "editor.active_line_number": "#f0f6fcff",
+            "editor.active_wrap_guide": "#3d444db3",
+            "editor.background": "#0d1117ff",
+            "editor.document_highlight.read_background": "#4493f84d",
+            "editor.document_highlight.write_background": "#4493f833",
+            "editor.foreground": "#f0f6fcff",
+            "editor.gutter.background": "#0d1117ff",
+            "editor.highlighted_line.background": "#656c7633",
+            "editor.invisible": "#656c7699",
+            "editor.line_number": "#9198a1ff",
+            "editor.subheader.background": "#151b23ff",
+            "editor.wrap_guide": "#3d444db3",
+            "element.active": "#656c7633",
+            "element.background": "#656c7633",
+            "element.disabled": "#212830ff",
+            "element.hover": "#656c7633",
+            "element.selected": "#656c7633",
+            "elevated_surface.background": "#151b23ff",
+            "error": "#db6d28ff",
+            "error.background": "#151b23ff",
+            "error.border": "#3d444db3",
+            "ghost_element.active": "#656c7633",
+            "ghost_element.background": "#00000000",
+            "ghost_element.disabled": "#212830ff",
+            "ghost_element.hover": "#0d1117ff",
+            "ghost_element.selected": "#656c7633",
+            "hidden": "#656c7699",
+            "hidden.background": "#212830ff",
+            "hidden.border": "#656c761a",
+            "hint": "#9198a1ff",
+            "hint.background": "#151b23ff",
+            "hint.border": "#3d444db3",
+            "icon": "#f0f6fcff",
+            "icon.background": "#0d1117ff",
+            "icon.border": "#3d444dff",
+            "icon.accent": "#4493f8ff",
+            "icon.muted": "#9198a1ff",
+            "icon.disabled": "#656c7699",
+            "ignored": "#9198a1ff",
+            "ignored.background": "#212830ff",
+            "ignored.border": "#656c761a",
+            "info": "#d29922ff",
+            "info.background": "#151b23ff",
+            "info.border": "#3d444db3",
+            "link_text.hover": "#4493f8ff",
+            "modified": "#d29922ff",
+            "modified.background": "#bb800926",
+            "modified.border": "#bb800966",
+            "pane.focused_border": "#3d444dff",
+            "panel.background": "#010409ff",
+            "panel.focused_border": "#3d444dff",
+            "predictive.background": "#656c7633",
+            "predictive.border": "#3d444db3",
+            "renamed": "#58a6ffff",
+            "renamed.background": "#388bfd26",
+            "renamed.border": "#388bfd66",
+            "scrollbar.thumb.border": "#00000000",
+            "scrollbar.thumb.hover_background": "#151b23ff",
+            "scrollbar.track.background": "#00000000",
+            "scrollbar.track.border": "#00000000",
+            "search.match_background": "#f2cc604d",
+            "status_bar.background": "#010409ff",
+            "success": "#58a6ffff",
+            "success.background": "#388bfd26",
+            "success.border": "#388bfd66",
+            "surface.background": "#010409ff",
+            "tab.active_background": "#0d1117ff",
+            "tab.inactive_background": "#010409ff",
+            "tab_bar.background": "#010409ff",
+            "terminal.ansi.black": "#2f3742ff",
+            "terminal.ansi.bright_black": "#656c76ff",
+            "terminal.ansi.dim_black": "#2f3742ff",
+            "terminal.ansi.blue": "#58a6ffff",
+            "terminal.ansi.bright_blue": "#79c0ffff",
+            "terminal.ansi.dim_blue": "#58a6ffff",
+            "terminal.ansi.cyan": "#39c5cfff",
+            "terminal.ansi.bright_cyan": "#56d4ddff",
+            "terminal.ansi.dim_cyan": "#39c5cfff",
+            "terminal.ansi.green": "#58a6ffff",
+            "terminal.ansi.bright_green": "#79c0ffff",
+            "terminal.ansi.dim_green": "#58a6ffff",
+            "terminal.ansi.magenta": "#be8fffff",
+            "terminal.ansi.bright_magenta": "#d2a8ffff",
+            "terminal.ansi.dim_magenta": "#be8fffff",
+            "terminal.ansi.red": "#f0883eff",
+            "terminal.ansi.bright_red": "#ffa657ff",
+            "terminal.ansi.dim_red": "#f0883eff",
+            "terminal.ansi.white": "#f0f6fcff",
+            "terminal.ansi.bright_white": "#ffffffff",
+            "terminal.ansi.dim_white": "#f0f6fcff",
+            "terminal.ansi.yellow": "#d29922ff",
+            "terminal.ansi.bright_yellow": "#e3b341ff",
+            "terminal.ansi.dim_yellow": "#d29922ff",
+            "terminal.background": "#010409ff",
+            "terminal.bright_foreground": "#ffffffff",
+            "terminal.dim_foreground": "#9198a1ff",
+            "terminal.foreground": "#f0f6fcff",
+            "text": "#f0f6fcff",
+            "text.accent": "#4493f8ff",
+            "text.disabled": "#656c7699",
+            "text.muted": "#f0f6fcff",
+            "title_bar.background": "#010409ff",
+            "toolbar.background": "#0d1117ff",
+            "unreachable": "#656c7699",
+            "unreachable.background": "#212830ff",
+            "unreachable.border": "#656c761a",
+            "warning": "#d29922ff",
+            "warning.background": "#151b23ff",
+            "warning.border": "#3d444db3",
+            "players": [
+              {
+                "cursor": "#0576ffff",
+                "background": "#0576ffff",
+                "selection": "#0576ff66"
+              },
+              {
+                "cursor": "#984b10ff",
+                "background": "#984b10ff",
+                "selection": "#984b1066"
+              },
+              {
+                "cursor": "#d34591ff",
+                "background": "#d34591ff",
+                "selection": "#d3459166"
+              },
+              {
+                "cursor": "#2f6f37ff",
+                "background": "#2f6f37ff",
+                "selection": "#2f6f3766"
+              },
+              {
+                "cursor": "#975bf1ff",
+                "background": "#975bf1ff",
+                "selection": "#975bf166"
+              },
+              {
+                "cursor": "#895906ff",
+                "background": "#895906ff",
+                "selection": "#89590666"
+              },
+              {
+                "cursor": "#106c70ff",
+                "background": "#106c70ff",
+                "selection": "#106c7066"
+              },
+              {
+                "cursor": "#eb3342ff",
+                "background": "#eb3342ff",
+                "selection": "#eb334266"
+              }
+            ],
+            "syntax": {
+              "attribute": {
+                "color": null,
+                "font_style": null,
+                "font_weight": null
+              },
+              "boolean": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment": {
+                "color": "#9198a1ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment.doc": {
+                "color": "#9198a1ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constant": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constructor": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "embedded": {
+                "color": "#ff7b72ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "emphasis": {
+                "color": null,
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "emphasis.strong": {
+                "color": null,
+                "font_style": null,
+                "font_weight": 700
+              },
+              "enum": {
+                "color": "#ffa657ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function": {
+                "color": "#d2a8ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function.method": {
+                "color": "#d2a8ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function.special.definition": {
+                "color": "#d2a8ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "hint": {
+                "color": "#9198a1ff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "keyword": {
+                "color": "#ff7b72ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "label": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "link_text": {
+                "color": "#a5d6ffff",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "link_uri": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "number": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "operator": {
+                "color": "#f0f6fcff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "predictive": {
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "preproc": {
+                "color": "#ff7b72ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "primary": {
+                "color": "#f0f6fcff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "property": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation": {
+                "color": "#f0f6fcff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.bracket": {
+                "color": "#f0f6fcff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.delimiter": {
+                "color": "#f0f6fcff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.list_marker": {
+                "color": "#ffa657ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.special": {
+                "color": "#ff7b72ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string": {
+                "color": "#a5d6ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.escape": {
+                "color": "#7ee787ff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "string.regex": {
+                "color": "#a5d6ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special.symbol": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "tag": {
+                "color": "#7ee787ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "text.literal": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "title": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "type": {
+                "color": "#ffa657ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable": {
+                "color": "#f0f6fcff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable.special": {
+                "color": "#ff7b72ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variant": {
+                "color": "#ffa657ff",
+                "font_style": null,
+                "font_weight": null
+              }
+            }
+          }
+        },
+        {
+          "appearance": "dark",
+          "name": "Github Dark High Contrast",
+          "style": {
+            "background": "#010409ff",
+            "border": "#b7bdc8ff",
+            "border.disabled": "#9198a11f",
+            "border.focused": "#409effff",
+            "border.selected": "#409effff",
+            "border.transparent": "#00000000",
+            "border.variant": "#b7bdc8ff",
+            "conflict": "#fe9a2dff",
+            "conflict.background": "#f48b251a",
+            "conflict.border": "#f48b25ff",
+            "created": "#2bd853ff",
+            "created.background": "#0ac74026",
+            "created.border": "#0ac740ff",
+            "deleted": "#ff9492ff",
+            "deleted.background": "#ff80801a",
+            "deleted.border": "#ff8080ff",
+            "drop_target.background": "#5cacff1a",
+            "editor.active_line.background": "#151b23ff",
+            "editor.active_line_number": "#ffffffff",
+            "editor.active_wrap_guide": "#b7bdc8ff",
+            "editor.background": "#010409ff",
+            "editor.document_highlight.read_background": "#74b9ff4d",
+            "editor.document_highlight.write_background": "#74b9ff33",
+            "editor.foreground": "#ffffffff",
+            "editor.gutter.background": "#010409ff",
+            "editor.highlighted_line.background": "#212830ff",
+            "editor.invisible": "#9198a199",
+            "editor.line_number": "#b7bdc8ff",
+            "editor.subheader.background": "#151b23ff",
+            "editor.wrap_guide": "#b7bdc8ff",
+            "element.active": "#212830ff",
+            "element.background": "#212830ff",
+            "element.disabled": "#262c36ff",
+            "element.hover": "#212830ff",
+            "element.selected": "#212830ff",
+            "elevated_surface.background": "#151b23ff",
+            "error": "#ff9492ff",
+            "error.background": "#151b23ff",
+            "error.border": "#b7bdc8ff",
+            "ghost_element.active": "#212830ff",
+            "ghost_element.background": "#00000000",
+            "ghost_element.disabled": "#262c36ff",
+            "ghost_element.hover": "#010409ff",
+            "ghost_element.selected": "#212830ff",
+            "hidden": "#9198a199",
+            "hidden.background": "#262c36ff",
+            "hidden.border": "#9198a11f",
+            "hint": "#b7bdc8ff",
+            "hint.background": "#151b23ff",
+            "hint.border": "#b7bdc8ff",
+            "icon": "#ffffffff",
+            "icon.background": "#010409ff",
+            "icon.border": "#b7bdc8ff",
+            "icon.accent": "#74b9ffff",
+            "icon.muted": "#b7bdc8ff",
+            "icon.disabled": "#9198a199",
+            "ignored": "#b7bdc8ff",
+            "ignored.background": "#262c36ff",
+            "ignored.border": "#9198a11f",
+            "info": "#f0b72fff",
+            "info.background": "#151b23ff",
+            "info.border": "#b7bdc8ff",
+            "link_text.hover": "#74b9ffff",
+            "modified": "#f0b72fff",
+            "modified.background": "#edaa2726",
+            "modified.border": "#edaa27ff",
+            "pane.focused_border": "#b7bdc8ff",
+            "panel.background": "#010409ff",
+            "panel.focused_border": "#b7bdc8ff",
+            "predictive.background": "#212830ff",
+            "predictive.border": "#b7bdc8ff",
+            "renamed": "#2bd853ff",
+            "renamed.background": "#0ac74026",
+            "renamed.border": "#0ac740ff",
+            "scrollbar.thumb.border": "#00000000",
+            "scrollbar.thumb.hover_background": "#151b23ff",
+            "scrollbar.track.background": "#00000000",
+            "scrollbar.track.border": "#00000000",
+            "search.match_background": "#fbd6694d",
+            "status_bar.background": "#010409ff",
+            "success": "#2bd853ff",
+            "success.background": "#0ac74026",
+            "success.border": "#0ac740ff",
+            "surface.background": "#010409ff",
+            "tab.active_background": "#010409ff",
+            "tab.inactive_background": "#010409ff",
+            "tab_bar.background": "#010409ff",
+            "terminal.ansi.black": "#2f3742ff",
+            "terminal.ansi.bright_black": "#656c76ff",
+            "terminal.ansi.dim_black": "#2f3742ff",
+            "terminal.ansi.blue": "#71b7ffff",
+            "terminal.ansi.bright_blue": "#91cbffff",
+            "terminal.ansi.dim_blue": "#71b7ffff",
+            "terminal.ansi.cyan": "#39c5cfff",
+            "terminal.ansi.bright_cyan": "#56d4ddff",
+            "terminal.ansi.dim_cyan": "#39c5cfff",
+            "terminal.ansi.green": "#28d751ff",
+            "terminal.ansi.bright_green": "#4ae168ff",
+            "terminal.ansi.dim_green": "#28d751ff",
+            "terminal.ansi.magenta": "#cb9effff",
+            "terminal.ansi.bright_magenta": "#dbb7ffff",
+            "terminal.ansi.dim_magenta": "#cb9effff",
+            "terminal.ansi.red": "#ff9492ff",
+            "terminal.ansi.bright_red": "#ffb1afff",
+            "terminal.ansi.dim_red": "#ff9492ff",
+            "terminal.ansi.white": "#f0f6fcff",
+            "terminal.ansi.bright_white": "#ffffffff",
+            "terminal.ansi.dim_white": "#f0f6fcff",
+            "terminal.ansi.yellow": "#f0b72fff",
+            "terminal.ansi.bright_yellow": "#f7c843ff",
+            "terminal.ansi.dim_yellow": "#f0b72fff",
+            "terminal.background": "#010409ff",
+            "terminal.bright_foreground": "#ffffffff",
+            "terminal.dim_foreground": "#b7bdc8ff",
+            "terminal.foreground": "#ffffffff",
+            "text": "#ffffffff",
+            "text.accent": "#74b9ffff",
+            "text.disabled": "#9198a199",
+            "text.muted": "#ffffffff",
+            "title_bar.background": "#010409ff",
+            "toolbar.background": "#010409ff",
+            "unreachable": "#9198a199",
+            "unreachable.background": "#262c36ff",
+            "unreachable.border": "#9198a11f",
+            "warning": "#f0b72fff",
+            "warning.background": "#151b23ff",
+            "warning.border": "#b7bdc8ff",
+            "players": [
+              {
+                "cursor": "#0576ffff",
+                "background": "#0576ffff",
+                "selection": "#0576ff66"
+              },
+              {
+                "cursor": "#984b10ff",
+                "background": "#984b10ff",
+                "selection": "#984b1066"
+              },
+              {
+                "cursor": "#d34591ff",
+                "background": "#d34591ff",
+                "selection": "#d3459166"
+              },
+              {
+                "cursor": "#2f6f37ff",
+                "background": "#2f6f37ff",
+                "selection": "#2f6f3766"
+              },
+              {
+                "cursor": "#975bf1ff",
+                "background": "#975bf1ff",
+                "selection": "#975bf166"
+              },
+              {
+                "cursor": "#895906ff",
+                "background": "#895906ff",
+                "selection": "#89590666"
+              },
+              {
+                "cursor": "#106c70ff",
+                "background": "#106c70ff",
+                "selection": "#106c7066"
+              },
+              {
+                "cursor": "#eb3342ff",
+                "background": "#eb3342ff",
+                "selection": "#eb334266"
+              }
+            ],
+            "syntax": {
+              "attribute": {
+                "color": null,
+                "font_style": null,
+                "font_weight": null
+              },
+              "boolean": {
+                "color": "#91cbffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment": {
+                "color": "#9198a1ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment.doc": {
+                "color": "#9198a1ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constant": {
+                "color": "#91cbffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constructor": {
+                "color": "#91cbffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "embedded": {
+                "color": "#ff9492ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "emphasis": {
+                "color": null,
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "emphasis.strong": {
+                "color": null,
+                "font_style": null,
+                "font_weight": 700
+              },
+              "enum": {
+                "color": "#ffb757ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function": {
+                "color": "#dbb7ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function.method": {
+                "color": "#dbb7ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function.special.definition": {
+                "color": "#dbb7ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "hint": {
+                "color": "#b7bdc8ff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "keyword": {
+                "color": "#ff9492ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "label": {
+                "color": "#91cbffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "link_text": {
+                "color": "#addcffff",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "link_uri": {
+                "color": "#91cbffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "number": {
+                "color": "#91cbffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "operator": {
+                "color": "#ffffffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "predictive": {
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "preproc": {
+                "color": "#ff9492ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "primary": {
+                "color": "#ffffffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "property": {
+                "color": "#91cbffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation": {
+                "color": "#ffffffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.bracket": {
+                "color": "#ffffffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.delimiter": {
+                "color": "#ffffffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.list_marker": {
+                "color": "#ffb757ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.special": {
+                "color": "#ff9492ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string": {
+                "color": "#addcffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.escape": {
+                "color": "#72f088ff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "string.regex": {
+                "color": "#addcffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special": {
+                "color": "#91cbffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special.symbol": {
+                "color": "#91cbffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "tag": {
+                "color": "#72f088ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "text.literal": {
+                "color": "#91cbffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "title": {
+                "color": "#91cbffff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "type": {
+                "color": "#ffb757ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable": {
+                "color": "#ffffffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable.special": {
+                "color": "#ff9492ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variant": {
+                "color": "#ffb757ff",
+                "font_style": null,
+                "font_weight": null
+              }
+            }
+          }
+        },
+        {
+          "appearance": "dark",
+          "name": "Github Dark Tritanopia",
+          "style": {
+            "background": "#0d1117ff",
+            "border": "#3d444dff",
+            "border.disabled": "#656c761a",
+            "border.focused": "#1f6febff",
+            "border.selected": "#1f6febff",
+            "border.transparent": "#00000000",
+            "border.variant": "#3d444db3",
+            "conflict": "#f85149ff",
+            "conflict.background": "#f851491a",
+            "conflict.border": "#f8514966",
+            "created": "#58a6ffff",
+            "created.background": "#388bfd26",
+            "created.border": "#388bfd66",
+            "deleted": "#f85149ff",
+            "deleted.background": "#f851491a",
+            "deleted.border": "#f8514966",
+            "drop_target.background": "#388bfd1a",
+            "editor.active_line.background": "#151b23ff",
+            "editor.active_line_number": "#f0f6fcff",
+            "editor.active_wrap_guide": "#3d444db3",
+            "editor.background": "#0d1117ff",
+            "editor.document_highlight.read_background": "#4493f84d",
+            "editor.document_highlight.write_background": "#4493f833",
+            "editor.foreground": "#f0f6fcff",
+            "editor.gutter.background": "#0d1117ff",
+            "editor.highlighted_line.background": "#656c7633",
+            "editor.invisible": "#656c7699",
+            "editor.line_number": "#9198a1ff",
+            "editor.subheader.background": "#151b23ff",
+            "editor.wrap_guide": "#3d444db3",
+            "element.active": "#656c7633",
+            "element.background": "#656c7633",
+            "element.disabled": "#212830ff",
+            "element.hover": "#656c7633",
+            "element.selected": "#656c7633",
+            "elevated_surface.background": "#151b23ff",
+            "error": "#f85149ff",
+            "error.background": "#151b23ff",
+            "error.border": "#3d444db3",
+            "ghost_element.active": "#656c7633",
+            "ghost_element.background": "#00000000",
+            "ghost_element.disabled": "#212830ff",
+            "ghost_element.hover": "#0d1117ff",
+            "ghost_element.selected": "#656c7633",
+            "hidden": "#656c7699",
+            "hidden.background": "#212830ff",
+            "hidden.border": "#656c761a",
+            "hint": "#9198a1ff",
+            "hint.background": "#151b23ff",
+            "hint.border": "#3d444db3",
+            "icon": "#f0f6fcff",
+            "icon.background": "#0d1117ff",
+            "icon.border": "#3d444dff",
+            "icon.accent": "#4493f8ff",
+            "icon.muted": "#9198a1ff",
+            "icon.disabled": "#656c7699",
+            "ignored": "#9198a1ff",
+            "ignored.background": "#212830ff",
+            "ignored.border": "#656c761a",
+            "info": "#d29922ff",
+            "info.background": "#151b23ff",
+            "info.border": "#3d444db3",
+            "link_text.hover": "#4493f8ff",
+            "modified": "#d29922ff",
+            "modified.background": "#bb800926",
+            "modified.border": "#bb800966",
+            "pane.focused_border": "#3d444dff",
+            "panel.background": "#010409ff",
+            "panel.focused_border": "#3d444dff",
+            "predictive.background": "#656c7633",
+            "predictive.border": "#3d444db3",
+            "renamed": "#58a6ffff",
+            "renamed.background": "#388bfd26",
+            "renamed.border": "#388bfd66",
+            "scrollbar.thumb.border": "#00000000",
+            "scrollbar.thumb.hover_background": "#151b23ff",
+            "scrollbar.track.background": "#00000000",
+            "scrollbar.track.border": "#00000000",
+            "search.match_background": "#f2cc604d",
+            "status_bar.background": "#010409ff",
+            "success": "#58a6ffff",
+            "success.background": "#388bfd26",
+            "success.border": "#388bfd66",
+            "surface.background": "#010409ff",
+            "tab.active_background": "#0d1117ff",
+            "tab.inactive_background": "#010409ff",
+            "tab_bar.background": "#010409ff",
+            "terminal.ansi.black": "#2f3742ff",
+            "terminal.ansi.bright_black": "#656c76ff",
+            "terminal.ansi.dim_black": "#2f3742ff",
+            "terminal.ansi.blue": "#58a6ffff",
+            "terminal.ansi.bright_blue": "#79c0ffff",
+            "terminal.ansi.dim_blue": "#58a6ffff",
+            "terminal.ansi.cyan": "#39c5cfff",
+            "terminal.ansi.bright_cyan": "#56d4ddff",
+            "terminal.ansi.dim_cyan": "#39c5cfff",
+            "terminal.ansi.green": "#58a6ffff",
+            "terminal.ansi.bright_green": "#79c0ffff",
+            "terminal.ansi.dim_green": "#58a6ffff",
+            "terminal.ansi.magenta": "#be8fffff",
+            "terminal.ansi.bright_magenta": "#d2a8ffff",
+            "terminal.ansi.dim_magenta": "#be8fffff",
+            "terminal.ansi.red": "#ff7b72ff",
+            "terminal.ansi.bright_red": "#ffa198ff",
+            "terminal.ansi.dim_red": "#ff7b72ff",
+            "terminal.ansi.white": "#f0f6fcff",
+            "terminal.ansi.bright_white": "#ffffffff",
+            "terminal.ansi.dim_white": "#f0f6fcff",
+            "terminal.ansi.yellow": "#d29922ff",
+            "terminal.ansi.bright_yellow": "#e3b341ff",
+            "terminal.ansi.dim_yellow": "#d29922ff",
+            "terminal.background": "#010409ff",
+            "terminal.bright_foreground": "#ffffffff",
+            "terminal.dim_foreground": "#9198a1ff",
+            "terminal.foreground": "#f0f6fcff",
+            "text": "#f0f6fcff",
+            "text.accent": "#4493f8ff",
+            "text.disabled": "#656c7699",
+            "text.muted": "#f0f6fcff",
+            "title_bar.background": "#010409ff",
+            "toolbar.background": "#0d1117ff",
+            "unreachable": "#656c7699",
+            "unreachable.background": "#212830ff",
+            "unreachable.border": "#656c761a",
+            "warning": "#d29922ff",
+            "warning.background": "#151b23ff",
+            "warning.border": "#3d444db3",
+            "players": [
+              {
+                "cursor": "#0576ffff",
+                "background": "#0576ffff",
+                "selection": "#0576ff66"
+              },
+              {
+                "cursor": "#984b10ff",
+                "background": "#984b10ff",
+                "selection": "#984b1066"
+              },
+              {
+                "cursor": "#d34591ff",
+                "background": "#d34591ff",
+                "selection": "#d3459166"
+              },
+              {
+                "cursor": "#2f6f37ff",
+                "background": "#2f6f37ff",
+                "selection": "#2f6f3766"
+              },
+              {
+                "cursor": "#975bf1ff",
+                "background": "#975bf1ff",
+                "selection": "#975bf166"
+              },
+              {
+                "cursor": "#895906ff",
+                "background": "#895906ff",
+                "selection": "#89590666"
+              },
+              {
+                "cursor": "#106c70ff",
+                "background": "#106c70ff",
+                "selection": "#106c7066"
+              },
+              {
+                "cursor": "#eb3342ff",
+                "background": "#eb3342ff",
+                "selection": "#eb334266"
+              }
+            ],
+            "syntax": {
+              "attribute": {
+                "color": null,
+                "font_style": null,
+                "font_weight": null
+              },
+              "boolean": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment": {
+                "color": "#9198a1ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment.doc": {
+                "color": "#9198a1ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constant": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constructor": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "embedded": {
+                "color": "#ff7b72ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "emphasis": {
+                "color": null,
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "emphasis.strong": {
+                "color": null,
+                "font_style": null,
+                "font_weight": 700
+              },
+              "enum": {
+                "color": "#ffa657ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function": {
+                "color": "#d2a8ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function.method": {
+                "color": "#d2a8ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function.special.definition": {
+                "color": "#d2a8ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "hint": {
+                "color": "#9198a1ff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "keyword": {
+                "color": "#ff7b72ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "label": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "link_text": {
+                "color": "#a5d6ffff",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "link_uri": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "number": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "operator": {
+                "color": "#f0f6fcff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "predictive": {
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "preproc": {
+                "color": "#ff7b72ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "primary": {
+                "color": "#f0f6fcff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "property": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation": {
+                "color": "#f0f6fcff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.bracket": {
+                "color": "#f0f6fcff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.delimiter": {
+                "color": "#f0f6fcff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.list_marker": {
+                "color": "#ffa657ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.special": {
+                "color": "#ff7b72ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string": {
+                "color": "#a5d6ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.escape": {
+                "color": "#7ee787ff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "string.regex": {
+                "color": "#a5d6ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special.symbol": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "tag": {
+                "color": "#7ee787ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "text.literal": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "title": {
+                "color": "#79c0ffff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "type": {
+                "color": "#ffa657ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable": {
+                "color": "#f0f6fcff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable.special": {
+                "color": "#ff7b72ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variant": {
+                "color": "#ffa657ff",
+                "font_style": null,
+                "font_weight": null
+              }
+            }
+          }
+        },
+        {
+          "appearance": "dark",
+          "name": "Github Dark Dimmed",
+          "style": {
+            "background": "#212830ff",
+            "border": "#3d444dff",
+            "border.disabled": "#656c761a",
+            "border.focused": "#316dcaff",
+            "border.selected": "#316dcaff",
+            "border.transparent": "#00000000",
+            "border.variant": "#3d444db3",
+            "conflict": "#cc6b2cff",
+            "conflict.background": "#cc6b2c1a",
+            "conflict.border": "#cc6b2c66",
+            "created": "#57ab5aff",
+            "created.background": "#46954a26",
+            "created.border": "#46954a66",
+            "deleted": "#e5534bff",
+            "deleted.background": "#e5534b1a",
+            "deleted.border": "#e5534b66",
+            "drop_target.background": "#4184e41a",
+            "editor.active_line.background": "#262c36ff",
+            "editor.active_line_number": "#d1d7e0ff",
+            "editor.active_wrap_guide": "#3d444db3",
+            "editor.background": "#212830ff",
+            "editor.document_highlight.read_background": "#478be64d",
+            "editor.document_highlight.write_background": "#478be633",
+            "editor.foreground": "#d1d7e0ff",
+            "editor.gutter.background": "#212830ff",
+            "editor.highlighted_line.background": "#656c7633",
+            "editor.invisible": "#656c76ff",
+            "editor.line_number": "#9198a1ff",
+            "editor.subheader.background": "#262c36ff",
+            "editor.wrap_guide": "#3d444db3",
+            "element.active": "#656c7633",
+            "element.background": "#656c7633",
+            "element.disabled": "#2a313cff",
+            "element.hover": "#656c7633",
+            "element.selected": "#656c7633",
+            "elevated_surface.background": "#262c36ff",
+            "error": "#e5534bff",
+            "error.background": "#262c36ff",
+            "error.border": "#3d444db3",
+            "ghost_element.active": "#656c7633",
+            "ghost_element.background": "#00000000",
+            "ghost_element.disabled": "#2a313cff",
+            "ghost_element.hover": "#212830ff",
+            "ghost_element.selected": "#656c7633",
+            "hidden": "#656c76ff",
+            "hidden.background": "#2a313cff",
+            "hidden.border": "#656c761a",
+            "hint": "#9198a1ff",
+            "hint.background": "#262c36ff",
+            "hint.border": "#3d444db3",
+            "icon": "#d1d7e0ff",
+            "icon.background": "#212830ff",
+            "icon.border": "#3d444dff",
+            "icon.accent": "#478be6ff",
+            "icon.muted": "#9198a1ff",
+            "icon.disabled": "#656c76ff",
+            "ignored": "#9198a1ff",
+            "ignored.background": "#2a313cff",
+            "ignored.border": "#656c761a",
+            "info": "#c69026ff",
+            "info.background": "#262c36ff",
+            "info.border": "#3d444db3",
+            "link_text.hover": "#478be6ff",
+            "modified": "#c69026ff",
+            "modified.background": "#ae7c1426",
+            "modified.border": "#ae7c1466",
+            "pane.focused_border": "#3d444dff",
+            "panel.background": "#151b23ff",
+            "panel.focused_border": "#3d444dff",
+            "predictive.background": "#656c7633",
+            "predictive.border": "#3d444db3",
+            "renamed": "#57ab5aff",
+            "renamed.background": "#46954a26",
+            "renamed.border": "#46954a66",
+            "scrollbar.thumb.border": "#00000000",
+            "scrollbar.thumb.hover_background": "#262c36ff",
+            "scrollbar.track.background": "#00000000",
+            "scrollbar.track.border": "#00000000",
+            "search.match_background": "#eac55f4d",
+            "status_bar.background": "#151b23ff",
+            "success": "#57ab5aff",
+            "success.background": "#46954a26",
+            "success.border": "#46954a66",
+            "surface.background": "#151b23ff",
+            "tab.active_background": "#212830ff",
+            "tab.inactive_background": "#151b23ff",
+            "tab_bar.background": "#151b23ff",
+            "terminal.ansi.black": "#2f3742ff",
+            "terminal.ansi.bright_black": "#656c76ff",
+            "terminal.ansi.dim_black": "#2f3742ff",
+            "terminal.ansi.blue": "#539bf5ff",
+            "terminal.ansi.bright_blue": "#6cb6ffff",
+            "terminal.ansi.dim_blue": "#539bf5ff",
+            "terminal.ansi.cyan": "#39c5cfff",
+            "terminal.ansi.bright_cyan": "#56d4ddff",
+            "terminal.ansi.dim_cyan": "#39c5cfff",
+            "terminal.ansi.green": "#57ab5aff",
+            "terminal.ansi.bright_green": "#6bc46dff",
+            "terminal.ansi.dim_green": "#57ab5aff",
+            "terminal.ansi.magenta": "#b083f0ff",
+            "terminal.ansi.bright_magenta": "#dcbdfbff",
+            "terminal.ansi.dim_magenta": "#b083f0ff",
+            "terminal.ansi.red": "#f47067ff",
+            "terminal.ansi.bright_red": "#ff938aff",
+            "terminal.ansi.dim_red": "#f47067ff",
+            "terminal.ansi.white": "#f0f6fcff",
+            "terminal.ansi.bright_white": "#cdd9e5ff",
+            "terminal.ansi.dim_white": "#f0f6fcff",
+            "terminal.ansi.yellow": "#c69026ff",
+            "terminal.ansi.bright_yellow": "#daaa3fff",
+            "terminal.ansi.dim_yellow": "#c69026ff",
+            "terminal.background": "#151b23ff",
+            "terminal.bright_foreground": "#f0f6fcff",
+            "terminal.dim_foreground": "#9198a1ff",
+            "terminal.foreground": "#d1d7e0ff",
+            "text": "#d1d7e0ff",
+            "text.accent": "#478be6ff",
+            "text.disabled": "#656c76ff",
+            "text.muted": "#d1d7e0ff",
+            "title_bar.background": "#151b23ff",
+            "toolbar.background": "#212830ff",
+            "unreachable": "#656c76ff",
+            "unreachable.background": "#2a313cff",
+            "unreachable.border": "#656c761a",
+            "warning": "#c69026ff",
+            "warning.background": "#262c36ff",
+            "warning.border": "#3d444db3",
+            "players": [
+              {
+                "cursor": "#0576ffff",
+                "background": "#0576ffff",
+                "selection": "#0576ff66"
+              },
+              {
+                "cursor": "#984b10ff",
+                "background": "#984b10ff",
+                "selection": "#984b1066"
+              },
+              {
+                "cursor": "#d34591ff",
+                "background": "#d34591ff",
+                "selection": "#d3459166"
+              },
+              {
+                "cursor": "#2f6f37ff",
+                "background": "#2f6f37ff",
+                "selection": "#2f6f3766"
+              },
+              {
+                "cursor": "#975bf1ff",
+                "background": "#975bf1ff",
+                "selection": "#975bf166"
+              },
+              {
+                "cursor": "#895906ff",
+                "background": "#895906ff",
+                "selection": "#89590666"
+              },
+              {
+                "cursor": "#106c70ff",
+                "background": "#106c70ff",
+                "selection": "#106c7066"
+              },
+              {
+                "cursor": "#eb3342ff",
+                "background": "#eb3342ff",
+                "selection": "#eb334266"
+              }
+            ],
+            "syntax": {
+              "attribute": {
+                "color": null,
+                "font_style": null,
+                "font_weight": null
+              },
+              "boolean": {
+                "color": "#6cb6ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment": {
+                "color": "#9198a1ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "comment.doc": {
+                "color": "#9198a1ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constant": {
+                "color": "#6cb6ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "constructor": {
+                "color": "#6cb6ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "embedded": {
+                "color": "#f47067ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "emphasis": {
+                "color": null,
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "emphasis.strong": {
+                "color": null,
+                "font_style": null,
+                "font_weight": 700
+              },
+              "enum": {
+                "color": "#f69d50ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function": {
+                "color": "#dcbdfbff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function.method": {
+                "color": "#dcbdfbff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function.special.definition": {
+                "color": "#dcbdfbff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "hint": {
+                "color": "#9198a1ff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "keyword": {
+                "color": "#f47067ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "label": {
+                "color": "#6cb6ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "link_text": {
+                "color": "#96d0ffff",
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "link_uri": {
+                "color": "#6cb6ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "number": {
+                "color": "#6cb6ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "operator": {
+                "color": "#d1d7e0ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "predictive": {
+                "font_style": "italic",
+                "font_weight": null
+              },
+              "preproc": {
+                "color": "#f47067ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "primary": {
+                "color": "#d1d7e0ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "property": {
+                "color": "#6cb6ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation": {
+                "color": "#d1d7e0ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.bracket": {
+                "color": "#d1d7e0ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.delimiter": {
+                "color": "#d1d7e0ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.list_marker": {
+                "color": "#f69d50ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "punctuation.special": {
+                "color": "#f47067ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string": {
+                "color": "#96d0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.escape": {
+                "color": "#8ddb8cff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "string.regex": {
+                "color": "#96d0ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special": {
+                "color": "#6cb6ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "string.special.symbol": {
+                "color": "#6cb6ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "tag": {
+                "color": "#8ddb8cff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "text.literal": {
+                "color": "#6cb6ffff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "title": {
+                "color": "#6cb6ffff",
+                "font_style": null,
+                "font_weight": 700
+              },
+              "type": {
+                "color": "#f69d50ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable": {
+                "color": "#d1d7e0ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable.special": {
+                "color": "#f47067ff",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variant": {
+                "color": "#f69d50ff",
+                "font_style": null,
+                "font_weight": null
+              }
+            }
+          }
+        }
+      ]
+    },
+    "userId": null,
+    "installCount": 38732
+  },
+  {
+    "id": "one-dark-pro",
+    "name": "One Dark Pro",
+    "author": "MordFustang21",
+    "updatedDate": 1727098958000,
+    "versionHash": "0.0.7",
+    "bundled": true,
+    "repoUrl": "https://github.com/mordfustang21/zed-one-dark-pro",
+    "repoStars": 19,
+    "theme": {
+      "name": "One Dark Pro",
+      "author": "One Dark Pro: Zed Theme Importer",
+      "themes": [
+        {
+          "name": "One Dark Pro",
+          "appearance": "dark",
+          "style": {
+            "border": "#3e4452",
+            "border.variant": "#3e4452",
+            "border.focused": "#3e4452",
+            "border.selected": "#3e4452",
+            "border.transparent": "#3e4452",
+            "border.disabled": "#3e4452",
+            "elevated_surface.background": "#1e2227",
+            "surface.background": null,
+            "background": "#23272e",
+            "element.background": "#404754",
+            "element.hover": "#2c313a",
+            "element.active": null,
+            "element.selected": "#2c313a",
+            "element.disabled": null,
+            "drop_target.background": null,
+            "ghost_element.background": null,
+            "ghost_element.hover": "#2c313a",
+            "ghost_element.active": null,
+            "ghost_element.selected": "#2c313a",
             "ghost_element.disabled": null,
             "text": null,
             "text.muted": null,
@@ -1566,91 +7110,90 @@
             "icon.disabled": null,
             "icon.placeholder": null,
             "icon.accent": null,
-            "status_bar.background": "#DDDDDD",
-            "title_bar.background": null,
-            "toolbar.background": "#F7F7F7",
-            "tab_bar.background": "#F0F0F0",
-            "tab.inactive_background": null,
-            "tab.active_background": null,
-            "search.match_background": null,
-            "panel.background": "#F0F0F0",
+            "status_bar.background": "#1e2227",
+            "title_bar.background": "#23272e",
+            "toolbar.background": "#23272e",
+            "tab_bar.background": "#1e2227",
+            "tab.inactive_background": "#1e2227",
+            "tab.active_background": "#23272e",
+            "search.match_background": "#74ade866",
+            "panel.background": "#23272e",
             "panel.focused_border": null,
-            "pane.focused_border": null,
-            "scrollbar.thumb.background": null,
-            "scrollbar.thumb.hover_background": null,
-            "scrollbar.thumb.border": null,
-            "scrollbar.track.background": "#F7F7F7",
+            "scrollbar_thumb.background": "#4e5666",
+            "scrollbar.thumb.hover_background": "#5a6375",
+            "scrollbar.thumb.border": "#4e5666",
+            "scrollbar.track.background": "#23272e",
             "scrollbar.track.border": null,
-            "editor.foreground": "#000",
-            "editor.background": "#F7F7F7",
-            "editor.gutter.background": "#F7F7F7",
+            "editor.foreground": "#abb2bf",
+            "editor.background": "#23272e",
+            "editor.gutter.background": "#23272e",
             "editor.subheader.background": null,
-            "editor.active_line.background": "#F0F0F0",
+            "editor.active_line.background": "#2c313c",
             "editor.highlighted_line.background": null,
-            "editor.line_number": "#9DA39A",
-            "editor.active_line_number": "#000",
+            "editor.line_number": "#495162",
+            "editor.active_line_number": "#abb2bf",
             "editor.invisible": null,
-            "editor.wrap_guide": null,
-            "editor.active_wrap_guide": null,
+            "editor.wrap_guide": "#3e4452",
+            "editor.active_wrap_guide": "#3e4452",
             "editor.document_highlight.read_background": null,
             "editor.document_highlight.write_background": null,
-            "terminal.background": null,
+            "terminal.background": "#23272e",
             "terminal.foreground": null,
             "terminal.bright_foreground": null,
             "terminal.dim_foreground": null,
-            "terminal.ansi.black": "#000000",
-            "terminal.ansi.bright_black": "#777777",
+            "terminal.ansi.black": "#3f4451",
+            "terminal.ansi.bright_black": "#4f5666",
             "terminal.ansi.dim_black": null,
-            "terminal.ansi.red": "#AA3731",
-            "terminal.ansi.bright_red": "#F05050",
+            "terminal.ansi.red": "#e05561",
+            "terminal.ansi.bright_red": "#ff616e",
             "terminal.ansi.dim_red": null,
-            "terminal.ansi.green": "#448C27",
-            "terminal.ansi.bright_green": "#60CB00",
+            "terminal.ansi.green": "#8cc265",
+            "terminal.ansi.bright_green": "#a5e075",
             "terminal.ansi.dim_green": null,
-            "terminal.ansi.yellow": "#CB9000",
-            "terminal.ansi.bright_yellow": "#FFBC5D",
+            "terminal.ansi.yellow": "#d18f52",
+            "terminal.ansi.bright_yellow": "#f0a45d",
             "terminal.ansi.dim_yellow": null,
-            "terminal.ansi.blue": "#325CC0",
-            "terminal.ansi.bright_blue": "#007ACC",
+            "terminal.ansi.blue": "#4aa5f0",
+            "terminal.ansi.bright_blue": "#4dc4ff",
             "terminal.ansi.dim_blue": null,
-            "terminal.ansi.magenta": "#7A3E9D",
-            "terminal.ansi.bright_magenta": "#E64CE6",
+            "terminal.ansi.magenta": "#c162de",
+            "terminal.ansi.bright_magenta": "#de73ff",
             "terminal.ansi.dim_magenta": null,
-            "terminal.ansi.cyan": "#0083B2",
-            "terminal.ansi.bright_cyan": "#00AACB",
+            "terminal.ansi.cyan": "#42b3c2",
+            "terminal.ansi.bright_cyan": "#4cd1e0",
             "terminal.ansi.dim_cyan": null,
-            "terminal.ansi.white": "#BBBBBB",
-            "terminal.ansi.bright_white": "#FFFFFF",
+            "terminal.ansi.white": "#d7dae0",
+            "terminal.ansi.bright_white": "#e6e6e6",
             "terminal.ansi.dim_white": null,
             "link_text.hover": null,
             "conflict": null,
             "conflict.background": null,
             "conflict.border": null,
-            "created": null,
+            "created": "#a5e075",
             "created.background": null,
             "created.border": null,
-            "deleted": null,
+            "deleted": "#ff616e",
             "deleted.background": null,
             "deleted.border": null,
-            "error": "#AA3731",
-            "error.background": null,
-            "error.border": null,
+            "error": "#c24038",
+            "error.background": "#1e2227",
+            "error.border": "#a03237",
             "hidden": null,
             "hidden.background": null,
             "hidden.border": null,
-            "hint": "#969696ff",
-            "hint.background": null,
-            "hint.border": null,
-            "ignored": null,
+            "hint": "#7a849c",
+            "hint.background": "#1e2227",
+            "hint.border": "#013b64",
+            "ignored": "#636b78",
             "ignored.background": null,
             "ignored.border": null,
             "info": null,
             "info.background": null,
             "info.border": null,
-            "modified": "#325CC0",
+            "modified": "#e5c07b",
             "modified.background": null,
             "modified.border": null,
-            "predictive": null,
+            "predictive": "#4D5970",
             "predictive.background": null,
             "predictive.border": null,
             "renamed": null,
@@ -1662,117 +7205,149 @@
             "unreachable": null,
             "unreachable.background": null,
             "unreachable.border": null,
-            "warning": "#CB9000",
-            "warning.background": null,
-            "warning.border": null,
+            "warning": "#d19a66",
+            "warning.background": "#1e2227",
+            "warning.border": "#89734d",
             "players": [
               {
-                "selection": "#BFDBFE"
+                "cursor": "#74ade8ff",
+                "background": "#74ade8ff",
+                "selection": "#74ade83d"
+              },
+              {
+                "cursor": "#be5046ff",
+                "background": "#be5046ff",
+                "selection": "#be50463d"
+              },
+              {
+                "cursor": "#bf956aff",
+                "background": "#bf956aff",
+                "selection": "#bf956a3d"
+              },
+              {
+                "cursor": "#b477cfff",
+                "background": "#b477cfff",
+                "selection": "#b477cf3d"
+              },
+              {
+                "cursor": "#6eb4bfff",
+                "background": "#6eb4bfff",
+                "selection": "#6eb4bf3d"
+              },
+              {
+                "cursor": "#d07277ff",
+                "background": "#d07277ff",
+                "selection": "#d072773d"
+              },
+              {
+                "cursor": "#dec184ff",
+                "background": "#dec184ff",
+                "selection": "#dec1843d"
+              },
+              {
+                "cursor": "#a1c181ff",
+                "background": "#a1c181ff",
+                "selection": "#a1c1813d"
               }
             ],
             "syntax": {
               "comment": {
-                "color": "#AA3731",
+                "color": "#7F838C",
                 "font_style": null,
                 "font_weight": null
               },
-              "comment.doc": {
-                "color": "#AA3731",
-                "font_style": null,
-                "font_weight": null
-              },
-              "string.doc": {
-                "color": "#AA3731",
-                "font_style": null,
-                "font_weight": null
-              },
-              "function": {
-                "color": "#325CC0",
-                "font_style": null,
-                "font_weight": null
-              },
-              "function.method": {
-                "color": "#000000",
-                "font_style": null,
-                "font_weight": null
-              },
-              "function.builtin": {
-                "color": "#000000",
+              "attribute": {
+                "color": "#d19a66",
                 "font_style": null,
                 "font_weight": null
               },
               "constant": {
-                "color": "#7A3E9D",
+                "color": "#d19a66",
                 "font_style": null,
                 "font_weight": null
               },
-              "label": {
-                "color": "#325CC0",
+              "constructor": {
+                "color": "#e06c75",
+                "font_style": null,
+                "font_weight": null
+              },
+              "embedded": {
+                "color": "#abb2bf",
+                "font_style": null,
+                "font_weight": null
+              },
+              "function": {
+                "color": "#61afef",
+                "font_style": null,
+                "font_weight": null
+              },
+              "keyword": {
+                "color": "#c678dd",
                 "font_style": null,
                 "font_weight": null
               },
               "number": {
-                "color": "#7A3E9D",
+                "color": "#d19a66",
                 "font_style": null,
                 "font_weight": null
               },
-              "punctuation": {
-                "color": "#777777",
+              "operator": {
+                "color": "#abb2bf",
                 "font_style": null,
                 "font_weight": null
               },
-              "punctuation.bracket": {
-                "color": "#777777",
-                "font_style": null,
-                "font_weight": null
-              },
-              "punctuation.delimiter": {
-                "color": "#777777",
-                "font_style": null,
-                "font_weight": null
-              },
-              "punctuation.list_marker": {
-                "color": "#777777",
-                "font_style": null,
-                "font_weight": null
-              },
-              "punctuation.special": {
-                "color": "#777777",
+              "property": {
+                "color": "#e06c75",
                 "font_style": null,
                 "font_weight": null
               },
               "string": {
-                "color": "#448C27",
+                "color": "#98c379",
                 "font_style": null,
                 "font_weight": null
               },
               "string.escape": {
-                "color": "#7A3E9D",
+                "color": "#98c379",
                 "font_style": null,
                 "font_weight": null
               },
               "string.regex": {
-                "color": "#448C27",
+                "color": "#98c379",
                 "font_style": null,
                 "font_weight": null
               },
               "string.special": {
-                "color": "#448C27",
+                "color": "#56b6c2",
                 "font_style": null,
                 "font_weight": null
               },
               "string.special.symbol": {
-                "color": "#448C27",
+                "color": "#56b6c2",
+                "font_style": null,
+                "font_weight": null
+              },
+              "tag": {
+                "color": "#e06c75",
                 "font_style": null,
                 "font_weight": null
               },
               "text.literal": {
-                "color": "#448C27",
+                "color": "#98c379",
                 "font_style": null,
                 "font_weight": null
               },
-              "title": {
-                "color": "#325CC0",
+              "type": {
+                "color": "#e5c07b",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable": {
+                "color": "#e06c75",
+                "font_style": null,
+                "font_weight": null
+              },
+              "variable.special": {
+                "color": "#e5c07b",
                 "font_style": null,
                 "font_weight": null
               }
@@ -1782,6 +7357,6 @@
       ]
     },
     "userId": null,
-    "installCount": 623
+    "installCount": 36634
   }
 ]

--- a/dev/syncZedThemes.ts
+++ b/dev/syncZedThemes.ts
@@ -2,44 +2,23 @@
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import json5 from 'json5';
-import { fs, path, $, argv, cd, within } from 'zx';
+import { fs, path, $, argv } from 'zx';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 $.verbose = false;
 
-const dir = process.env.CI ? '.tmp/zed-extensions' : '/tmp/zed-extensions';
-let folders: string[] = [];
-
-await within(async () => {
-  // Fetch repo, pull latest submodules
-  if (!process.env.CI && !(await fs.exists(dir))) {
-    console.log('Cloning extensions repo...');
-    await $`git clone git@github.com:zed-industries/extensions.git ${dir}`;
-  }
-
-  cd(dir);
-
-  console.log("Pull latest's submodules...");
-
-  await $`git pull`;
-  await $`git -c submodule.extensions/meson.update=none submodule update --init --recursive`;
-
-  cd('./extensions');
-  const cmd = await $`echo *`.quiet();
-  folders = (await cmd.stdout).trim().split(' ');
-});
-
-if (argv.local) {
-  console.log('Adding themes to local db.');
-} else {
-  console.log('Adding themes to remote db.');
+if (!process.env.GITHUB_TOKEN) {
+  throw new Error('GITHUB_TOKEN environment variable is not defined (https://github.com/settings/tokens)');
 }
 
-// Fetch the latest Zed Ext API Info
-const zedApi = 'https://api.zed.dev/extensions?max_schema_version=1';
-const zedApiCmd = await $`curl ${zedApi}`.quiet();
+if (argv.local) {
+  console.log('Adding themes to local db');
+} else {
+  console.log('Adding themes to remote db');
+}
+
 type ExtInfo = {
   id: string;
   name: string;
@@ -52,71 +31,64 @@ type ExtInfo = {
   published_at: string;
   download_count: number;
 };
-let extInfo: Map<string, ExtInfo> = new Map();
+
+let extInfo: ExtInfo[] = [];
 try {
-  const data: ExtInfo[] = json5.parse(zedApiCmd.stdout).data;
-  extInfo = new Map(data.map((e) => [e.id, e]));
+  const res: { data: ExtInfo[] } = await fetch('https://api.zed.dev/extensions?max_schema_version=1').then((res) =>
+    res.json(),
+  );
+  extInfo = res.data;
 } catch (e) {
-  console.warn('Failed to parse zed extensions info from api', e);
+  const message = e instanceof Error ? e.message : e;
+  throw new Error(`Failed to parse zed extensions info from api: ${message}`);
 }
+
+console.log(`Fetched ${extInfo.length} extensions from Zed API`);
 
 let count = 0;
 const dbSeedThemes = [];
-for (const folder of folders) {
-  if (folder === 'meson') continue;
-
+for (const ext of extInfo) {
   try {
-    const id = folder.toLowerCase();
-    const file = (await $`ls ${dir}/extensions/${folder}/themes | head -1`.nothrow().quiet()).stdout.trim();
+    const repoUrl = ext.repository;
+    const repoPath = repoUrl.replaceAll(/.*github\.com\/|\.git$/g, '');
 
-    if (!file) {
-      console.log(`⏩ [${folder}] Skipping because it has no themes`);
+    const themeFile = await getThemeFile(repoPath);
+
+    if (!themeFile) {
+      console.log(`⏩ [${ext.id}] Skipping because it has no themes`);
       continue;
     }
 
-    const cmd = await $`cat ${dir}/extensions/${folder}/themes/${file}`.quiet();
-    const hash = await $`(cd ${dir}/extensions/${folder} && git rev-parse --short HEAD)`.quiet();
-    const repoDate = await $`(cd ${dir}/extensions/${folder} && git --no-pager log -1 --format="%ct")`.quiet();
-    const data = json5.parse(cmd.stdout);
-    const origin = await $`cd ${dir}/extensions/${folder} && git remote get-url origin`.quiet();
-    const repoUrl = origin.stdout?.trim();
-    const repoPath = repoUrl.replace(/^https?:\/\/github\.com\//, '').replace(/\.git$/, '');
-    const repoInfo =
-      await $`curl -s --header "Authorization: Bearer ${process.env.GITHUB_TOKEN}" https://api.github.com/repos/${repoPath}`.quiet();
-    const installCount = extInfo.get(id)?.download_count;
-    const updatedDateTs = new Date(extInfo.get(id)?.published_at ?? +repoDate.stdout.trim() * 1000).getTime();
+    const repoInfo = await getRepoInfo(repoPath);
+    const installCount = ext.download_count;
+    const updatedDateTs = new Date(ext.published_at).getTime();
 
-    if (!repoInfo.stdout?.match(/stargazers_count/)) {
-      if (repoInfo.stdout.match(/not found/i)) {
-        console.log(`! [${folder}] Unable to get GH repo info`);
-      } else {
-        console.log(repoInfo.stdout);
-      }
+    if (!repoInfo) {
+      console.warn(`⚠️  [${ext.id}] Unable to get GH repo info`);
     }
 
-    const repoStars = Number(repoInfo.stdout?.match(/stargazers_count"\s?:\s?(\d+)/)?.at(-1) ?? '0');
-
     const theme = {
-      id,
-      name: data.name,
-      author: data.author,
+      id: ext.id,
+      name: ext.name.replace(/\btheme\b/i, '').trim(),
+      author: ext.authors.map((s) => s.replaceAll(/<[^>]+>/g, '').trim()).join(', '),
       updatedDate: Number.isNaN(updatedDateTs) ? Date.now() : updatedDateTs,
-      versionHash: hash.stdout.trim(),
+      versionHash: ext.version,
       bundled: true,
       repoUrl,
-      repoStars,
-      theme: data,
+      repoStars: repoInfo?.stargazers_count ?? 0,
+      theme: themeFile,
       userId: null,
       installCount,
     };
-    if (dbSeedThemes.length <= 3) {
+
+    if (dbSeedThemes.length <= 5) {
       dbSeedThemes.push(theme);
     }
 
     const addInstallCount = typeof installCount === 'number';
-    const sql = `
+    const sqlCmd = `
       INSERT INTO themes (id, name, author, updatedDate, versionHash, bundled, repoUrl, repoStars, userId, theme ${addInstallCount ? ', installCount' : ''})
-      VALUES ('${theme.id}', '${theme.name}', '${theme.author}', ${theme.updatedDate}, '${theme.versionHash}', ${theme.bundled}, '${theme.repoUrl}', ${theme.repoStars}, NULL, '${JSON.stringify(theme.theme)}' ${addInstallCount ? `, ${theme.installCount}` : ''})
+      VALUES ('${theme.id}', '${sqlSafe(theme.name)}', '${theme.author}', ${theme.updatedDate}, '${theme.versionHash}', ${theme.bundled}, '${theme.repoUrl}', ${theme.repoStars}, NULL, '${JSON.stringify(theme.theme)}' ${addInstallCount ? `, ${theme.installCount}` : ''})
       ON CONFLICT (id) DO UPDATE
       SET name = EXCLUDED.name,
           author = EXCLUDED.author,
@@ -132,20 +104,220 @@ for (const folder of folders) {
 
     try {
       if (argv.local) {
-        await $`pnpm wrangler d1 execute zed_themes --command=${sql} --local`;
+        await $`pnpm wrangler d1 execute zed_themes --command=${sqlCmd} --local`;
       } else {
-        await $`pnpm wrangler d1 execute zed_themes --command=${sql} --remote`;
-        await $`pnpm wrangler d1 execute --env preview zed_themes_preview --command=${sql} --remote`;
+        await $`pnpm wrangler d1 execute zed_themes --command=${sqlCmd} --remote`;
+        await $`pnpm wrangler d1 execute --env preview zed_themes_preview --command=${sqlCmd} --remote`;
       }
-      console.log(`✅ [${folder}] Added theme [stars=${theme.repoStars}][author=${theme.author}][name=${theme.name}]`);
+      console.log(
+        `✅ [${ext.id}] Added theme [install=${theme.installCount}][stars=${theme.repoStars}][author=${theme.author}][name=${theme.name}]`,
+      );
     } catch (e) {
-      console.error(`❌ [${folder}] ${e instanceof Error ? e.message : e}`);
+      console.error(`❌ [${ext.id}] ${e instanceof Error ? e.message : e}`);
     }
 
     if (argv.limit && ++count >= argv.limit) break;
   } catch (e) {
-    console.error(`❌ [${folder}] ${e instanceof Error ? e.message : e}`);
+    console.error(`❌ [${ext.id}] ${e instanceof Error ? e.message : e}`);
   }
 }
 
 fs.writeFileSync(path.resolve(__dirname, 'dbSeedThemes.json'), JSON.stringify(dbSeedThemes, null, 2));
+
+type GHContent = {
+  name: string;
+  path: string;
+  sha: string;
+  size: number;
+  url: string;
+  html_url: string;
+  git_url: string;
+  download_url: string;
+  type: string;
+  _links: {
+    self: string;
+    git: string;
+    html: string;
+  };
+};
+
+async function getThemeFile(repoPath: string) {
+  try {
+    const res: GHContent[] = await fetch(`https://api.github.com/repos/${repoPath}/contents/themes`, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+      },
+    }).then((res) => res.json());
+    const files = res.filter((file) => file.name.endsWith('.json'));
+    if (files.length > 1) {
+      console.log(`⚠️  [${repoPath}] Has more than one theme json file found, using the first one`);
+    }
+    const url = files[0]?.download_url;
+    if (url) {
+      return fetch(url).then(async (res) => {
+        if (!res.ok) {
+          throw new Error(`GitHub API error: ${res.status} ${res.statusText}`);
+        }
+        return json5.parse(await res.text());
+      });
+    }
+  } catch (e) {
+    return undefined;
+  }
+}
+
+type GHRepoInfo = {
+  id: number;
+  node_id: string;
+  name: string;
+  full_name: string;
+  private: boolean;
+  owner: {
+    login: string;
+    id: number;
+    node_id: string;
+    avatar_url: string;
+    gravatar_id: string;
+    url: string;
+    html_url: string;
+    followers_url: string;
+    following_url: string;
+    gists_url: string;
+    starred_url: string;
+    subscriptions_url: string;
+    organizations_url: string;
+    repos_url: string;
+    events_url: string;
+    received_events_url: string;
+    type: string;
+    user_view_type: string;
+    site_admin: boolean;
+  };
+  html_url: string;
+  description: string;
+  fork: boolean;
+  url: string;
+  forks_url: string;
+  keys_url: string;
+  collaborators_url: string;
+  teams_url: string;
+  hooks_url: string;
+  issue_events_url: string;
+  events_url: string;
+  assignees_url: string;
+  branches_url: string;
+  tags_url: string;
+  blobs_url: string;
+  git_tags_url: string;
+  git_refs_url: string;
+  trees_url: string;
+  statuses_url: string;
+  languages_url: string;
+  stargazers_url: string;
+  contributors_url: string;
+  subscribers_url: string;
+  subscription_url: string;
+  commits_url: string;
+  git_commits_url: string;
+  comments_url: string;
+  issue_comment_url: string;
+  contents_url: string;
+  compare_url: string;
+  merges_url: string;
+  archive_url: string;
+  downloads_url: string;
+  issues_url: string;
+  pulls_url: string;
+  milestones_url: string;
+  notifications_url: string;
+  labels_url: string;
+  releases_url: string;
+  deployments_url: string;
+  created_at: string;
+  updated_at: string;
+  pushed_at: string;
+  git_url: string;
+  ssh_url: string;
+  clone_url: string;
+  svn_url: string;
+  homepage: string;
+  size: number;
+  stargazers_count: number;
+  watchers_count: number;
+  language: string;
+  has_issues: boolean;
+  has_projects: boolean;
+  has_downloads: boolean;
+  has_wiki: boolean;
+  has_pages: boolean;
+  has_discussions: boolean;
+  forks_count: number;
+  mirror_url: string | null;
+  archived: boolean;
+  disabled: boolean;
+  open_issues_count: number;
+  license: {
+    key: string;
+    name: string;
+    spdx_id: string;
+    url: string;
+    node_id: string;
+  };
+  allow_forking: boolean;
+  is_template: boolean;
+  web_commit_signoff_required: boolean;
+  topics: string[];
+  visibility: string;
+  forks: number;
+  open_issues: number;
+  watchers: number;
+  default_branch: string;
+  network_count: number;
+  subscribers_count: number;
+};
+
+async function getRepoInfo(repoPath: string): Promise<GHRepoInfo | undefined> {
+  try {
+    return await fetch(`https://api.github.com/repos/${repoPath}`, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+      },
+    }).then(async (res) => {
+      if (!res.ok) {
+        throw new Error(`GitHub API error: ${res.status} ${res.statusText}`);
+      }
+      return json5.parse(await res.text());
+    });
+  } catch (e) {
+    return undefined;
+  }
+}
+
+function sqlSafe(str: string) {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: required for sqlSafe
+  return str.replace(/[\0\x08\x09\x1a\n\r"'\\\%]/g, (char) => {
+    switch (char) {
+      case '\0':
+        return '\\0';
+      case '\x08':
+        return '\\b';
+      case '\x09':
+        return '\\t';
+      case '\x1a':
+        return '\\z';
+      case '\n':
+        return '\\n';
+      case '\r':
+        return '\\r';
+      case '"':
+      case "'":
+      case '\\':
+      case '%':
+        return `\\${char}`; // prepends a backslash to backslash, percent and double/single quotes
+      default:
+        return char;
+    }
+  });
+}

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -24,8 +24,8 @@ test('can search for themes', async ({ page }) => {
   await page.waitForTimeout(2000);
 
   const searchCount = await page.getByTestId('theme').count();
+  expect(page.url()).toContain(`search=${term.replaceAll(/\s/g, '+')}`);
   expect(searchCount).toBe(1);
-  expect(page.url()).toContain(`search=${term}`);
 
   // Test clearing search
   await page.getByTestId('search-input').click();
@@ -34,8 +34,8 @@ test('can search for themes', async ({ page }) => {
   await page.waitForTimeout(2000);
 
   const resetCount = await page.getByTestId('theme').count();
-  expect(resetCount).toBeGreaterThan(3);
   expect(page.url()).not.toContain('search=');
+  expect(resetCount).toBeGreaterThan(3);
 });
 
 test('search with no results displays appropriate message', async ({ page }) => {


### PR DESCRIPTION
Using the extensions repo was very slow with cloning all submodules, instead we use zed API and GH api to collect all the information needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced functionality for fetching and processing themes from a remote API.
	- Introduced a new function to retrieve theme files from GitHub repositories.

- **Improvements**
	- Simplified data handling by changing the structure of extension information.
	- Improved error handling with more descriptive messages.
	- Streamlined control flow for better efficiency.
	- Updated search term formatting to enhance search results.

- **Bug Fixes**
	- Removed redundant operations to enhance script performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->