### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   sync:
     name: sync
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/labithiotis/zed-themes/security/code-scanning/5](https://github.com/labithiotis/zed-themes/security/code-scanning/5)

To fix the problem, add a `permissions` block to the workflow or the specific job to explicitly set the minimum required permissions for the `GITHUB_TOKEN`. Since the CodeQL suggestion is to use `contents: read` as a minimal starting point, and there is no evidence in the workflow that broader permissions are needed, we should add `permissions: contents: read` at the job level (under `sync:`) or at the root of the workflow (applies to all jobs). This change should be made in `.github/workflows/sync.yml`, directly under the `sync:` job definition (after line 10), or at the top level (after line 2). No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tightened CI permissions by explicitly restricting the sync job’s token to read-only repository contents, enhancing security and aligning with least-privilege best practices.
  * No impact on product features, user experience, or workflow behavior.
  * Build and deployment processes remain unchanged while reducing risk and improving compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->