### PR TITLE
chore: add banner for official zed theme builder

### DIFF
--- a/app/components/AnnouncementBanner.tsx
+++ b/app/components/AnnouncementBanner.tsx
@@ -1,0 +1,67 @@
+import { ExternalLink } from 'lucide-react';
+import { Button } from './ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from './ui/dialog';
+
+const URL = 'https://zed.dev/theme-builder?ref=zed-themes.com';
+
+export function AnnouncementBanner() {
+  return (
+    <div className="fixed top-0 w-full bg-zed-600 text-white py-2 px-4 text-center text-sm z-30">
+      <div className="flex items-center justify-center gap-2 flex-wrap">
+        <span>Zed now has an official Theme Builder!</span>
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button
+              size="xs"
+              variant="ghost"
+              className="text-white hover:text-white hover:bg-zed-700 underline underline-offset-2"
+            >
+              Learn more
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Official Zed Theme Builder</DialogTitle>
+            </DialogHeader>
+            <div className="flex flex-col gap-4">
+              <p>
+                Zed has released an official Theme Builder that offers more features and is actively maintained by the
+                Zed team.
+              </p>
+              <p>We recommend migrating your themes to the official builder. You can do this by:</p>
+              <ol className="list-decimal list-inside space-y-2 text-sm">
+                <li>Download your themes from Zed Themes</li>
+                <li>
+                  Import them into the{' '}
+                  <a
+                    href={URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-zed-600 dark:text-zed-400 hover:underline"
+                  >
+                    official Zed Theme Builder
+                  </a>
+                </li>
+              </ol>
+              <p className="text-sm text-muted-foreground">
+                Zed Themes will remain active but is no longer being actively developed.
+              </p>
+              <Button asChild className="mt-2 bg-zed-600 hover:bg-zed-700">
+                <a href={URL} target="_blank" rel="noopener noreferrer">
+                  Go to Zed Theme Builder
+                  <ExternalLink className="ml-2 h-4 w-4" />
+                </a>
+              </Button>
+            </div>
+          </DialogContent>
+        </Dialog>
+        <Button asChild size="xs" className="bg-white text-zed-700 hover:bg-zed-100">
+          <a href={URL} target="_blank" rel="noopener noreferrer">
+            Try it now
+            <ExternalLink className="ml-1 h-3 w-3" />
+          </a>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/components/Layout.tsx
+++ b/app/components/Layout.tsx
@@ -1,12 +1,27 @@
+import { useLocation } from '@remix-run/react';
 import type { PropsWithChildren } from 'react';
 import { cn } from '~/utils';
+import { AnnouncementBanner } from './AnnouncementBanner';
 import { Navbar } from './Navbar';
 
 export function Layout({ children, className = 'container pt-6' }: PropsWithChildren<{ className?: string }>) {
+  const location = useLocation();
+  const isRoot = location.pathname === '/';
+  const showBanner = !isRoot;
+
   return (
     <div className="flex flex-col h-full w-full content-stretch bg-stone-300 dark:bg-stone-900 dark:text-zinc-200">
+      {showBanner && <AnnouncementBanner />}
       <Navbar />
-      <main className={cn('mt-20 md:mt-14 isolate', className)}>{children}</main>
+      <main
+        className={cn(
+          'isolate',
+          showBanner ? 'mt-[calc(2.5rem+5rem)] md:mt-[calc(2.5rem+3.5rem)]' : 'mt-20 md:mt-14',
+          className,
+        )}
+      >
+        {children}
+      </main>
     </div>
   );
 }

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -61,6 +61,7 @@ export function Navbar() {
   const lastSyncedLong = indexRouteData?.lastSynced ? longDateAndTime.format(new Date(indexRouteData.lastSynced)) : '';
 
   const isRoot = location.pathname === '/';
+  const showBanner = !isRoot;
 
   useEffect(() => {
     setTimeout(() => {
@@ -121,7 +122,10 @@ export function Navbar() {
 
   return (
     <header
-      className="fixed w-screen top-0 border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60"
+      className={cn(
+        'fixed w-screen border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60',
+        showBanner ? 'top-10' : 'top-0',
+      )}
       style={{ zIndex: 25 }}
     >
       <nav

--- a/app/routes/themes.$themeId.tsx
+++ b/app/routes/themes.$themeId.tsx
@@ -110,7 +110,7 @@ export default function ThemeById() {
   }, [hasTheme, params.themeId, setThemeFamily, navigate]);
 
   return (
-    <Layout className="h-full flex overflow-hidden mt-14 md:mt-14">
+    <Layout className="h-full flex overflow-hidden">
       <TokenHighlightProvider>
         <div className="flex-1 flex min-w-[1024] overflow-hidden" key={params.themeId}>
           <Side edit={data.editable} />

--- a/functions/[[path]].ts
+++ b/functions/[[path]].ts
@@ -9,5 +9,6 @@ type Build = Parameters<typeof createPagesFunctionHandler>['0']['build'];
 
 export const onRequest = createPagesFunctionHandler({
   build: build as unknown as Build,
+  // @ts-ignore
   getLoadContext: getLoadContext as GetLoadContextFunction<Env>,
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an announcement banner with a "Learn more" dialog and a secondary "Try it now" link to an external theme builder.

* **UI Improvements**
  * Layout and navbar positions adjusted so the banner displays and the main content shifts appropriately on non-root pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->